### PR TITLE
Skip incomplete-elements errors when publishing variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontent-ai/data-ops",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontent-ai/data-ops",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@kontent-ai/core-sdk": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/data-ops",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src/modules/importExport/importExportEntities/entities/workflows.ts
+++ b/src/modules/importExport/importExportEntities/entities/workflows.ts
@@ -151,12 +151,13 @@ const addWorkflows = async (
 
         const workflowContext: MapValues<ImportContext["workflowIdsByOldIds"]> = {
           selfId: response.id,
-          oldPublishedStepId: response.published_step.id,
-          oldArchivedStepId: response.archived_step.id,
-          oldScheduledStepId: response.scheduled_step.id,
+          oldPublishedStepId: importWorkflow.published_step.id,
+          oldArchivedStepId: importWorkflow.archived_step.id,
+          oldScheduledStepId: importWorkflow.scheduled_step.id,
           oldDraftStepId: draftStep.id,
           anyStepIdLeadingToPublishedStep:
-            response.steps.find(s => s.transitions_to.find(t => t.step.id === response.published_step.id))?.id ?? "",
+            importWorkflow.steps.find(s => s.transitions_to.find(t => t.step.id === response.published_step.id))?.id
+              ?? "",
         };
 
         return { workflow: [importWorkflow.id, workflowContext] as const, workflowSteps };


### PR DESCRIPTION
- it is possible to get into this state quite easily (e.g. adding restrictions to a content type after some variants of this type have been published) so failing on this is rather obtrusive

### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?