### PR TITLE
Fix typo in backup and restore command examples

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,9 @@ const initialYargs = emptyYargs
   .wrap(emptyYargs.terminalWidth())
   .env("DATA_OPS")
   .scriptName("data-ops")
-  .example("$0 environment export --apiKey=xxx --environmentId=xxx", "Creates a zip backup of a Kontent.ai environment")
+  .example("$0 environment backup --apiKey=xxx --environmentId=xxx", "Creates a zip backup of a Kontent.ai environment")
   .example(
-    "$0 environment import --apiKey=xxx --environmentId=xxx --fileName=backupFile",
+    "$0 environment restore --apiKey=xxx --environmentId=xxx --fileName=backupFile",
     "Populates the target Kontent.ai environment with data from the provided zip file.",
   )
   .epilogue("If you have any questions, contact us at devrel@kontent.ai.")


### PR DESCRIPTION
### Motivation

After renaming the commands, the examples shown in the help have not been updated.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
