### PR TITLE
Add option to authenticate to secure assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,6 @@ Below are the available commands:
 
 ### Examples
 
-**Backing up All Data from an Environment with Secure Asset Delivery Enabled**
-
-```bash
-npx @kontent-ai/data-ops@latest environment backup \
-  --environmentId <environment-id> \
-  --apiKey <Management-API-key> \
-  --secureAssetDeliveryKey=<Secure-Asset-Delivery-API-key>
-```
-
 **Creating an Environment Backup including Content Items and Assets**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ Below are the available commands:
 
 ### Examples
 
+**Backing up All Data from an Environment with Secure Asset Delivery Enabled**
+
+```bash
+npx @kontent-ai/data-ops@latest environment backup \
+  --environmentId <environment-id> \
+  --apiKey <Management-API-key> \
+  --secureAssetDeliveryKey=<Secure-Asset-Delivery-API-key>
+```
+
 **Creating an Environment Backup including Content Items and Assets**
 
 ```bash

--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -228,9 +228,10 @@ await restoreEnvironment(params);
 
 - **Scheduled Publishing Times**: The current API format doesn't support inclusion of the publishing time for variants scheduled to be published. The tool instead places scheduled variants into the draft step (the first step in the workflow).
 
-### Asset Size
+### Asset Limitations
 
 - **Asset Size Limit**: The Management API accepts only assets smaller than 100 MB. If your backup file contains assets larger than that (they can be uploaded through the UI), the tool won't be able to import them.
+- **Asset Quality**: Assets fetched by the tool may be compressed and metadata can be missing. You may find more information about asset compression in the [quality](https://kontent.ai/learn/docs/apis/image-transformation-api#a-quality-parameter) and [lossles](https://kontent.ai/learn/docs/apis/image-transformation-api#a-lossless-parameter) parameter documentation.
 
 ### Performance
 

--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -53,7 +53,7 @@ npx @kontent-ai/data-ops@latest environment backup --help
 | -------------------------- | ----------------------------------------------------------------------- |
 | `--environmentId`          | The ID of the environment you want to backup.                           |
 | `--apiKey`                 | The Management API key for the environment.                             |
-| `--secureAssetDeliveryKey` | (Optional) The secure asset delivery API key for the environment.       |
+| `--secureAssetDeliveryKey` | (Optional) The secure asset delivery API key for the environment.<br />Read more about enabling secure asset delivery in the [Kontent.ai documentation](https://kontent.ai/learn/docs/security/secure-access/javascript#a-retrieve-assets-securely).       |
 | `--fileName`               | (Optional) The name of the output `.zip` file. Default is `backup.zip`. |
 | `--include`                | (Optional) Specify entities to include in the backup.                   |
 | `--exclude`                | (Optional) Specify entities to exclude from the backup.                 |
@@ -76,6 +76,15 @@ npx @kontent-ai/data-ops@latest environment backup \
   --environmentId=<environment-id> \
   --apiKey=<Management-API-key> \
   --exclude roles
+```
+
+**Backing up All Data from an Environment with Secure Asset Delivery Enabled**
+
+```bash
+npx @kontent-ai/data-ops@latest environment backup \
+  --environmentId=<environment-id> \
+  --apiKey=<Management-API-key> \
+  --secureAssetDeliveryKey=<Secure-Asset-Delivery-API-key>
 ```
 
 ### Backup Programmatically

--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -53,10 +53,10 @@ npx @kontent-ai/data-ops@latest environment backup --help
 | -------------------------- | ----------------------------------------------------------------------- |
 | `--environmentId`          | The ID of the environment you want to backup.                           |
 | `--apiKey`                 | The Management API key for the environment.                             |
-| `--secureAssetDeliveryKey` | (Optional) The secure asset delivery API key for the environment.<br />Read more about enabling secure asset delivery in the [Kontent.ai documentation](https://kontent.ai/learn/docs/security/secure-access/javascript#a-retrieve-assets-securely).       |
 | `--fileName`               | (Optional) The name of the output `.zip` file. Default is `backup.zip`. |
 | `--include`                | (Optional) Specify entities to include in the backup.                   |
 | `--exclude`                | (Optional) Specify entities to exclude from the backup.                 |
+| `--secureAssetDeliveryKey` | (Optional) The secure asset delivery API key for the environment.<br />Read more about enabling secure asset delivery in the [Kontent.ai documentation](https://kontent.ai/learn/docs/security/secure-access/javascript#a-retrieve-assets-securely).       |
 | `--configFile`             | (Optional) Path to a JSON configuration file containing parameters.     |
 
 ### Examples
@@ -99,11 +99,11 @@ const params: BackupEnvironmentParams = {
   apiKey: "<mapi-key>",
   // Optional: specify output file name
   // fileName: "backup.zip",
-  // Optional: specify secure asset delivery API key
-  // secureAssetDeliveryKey: "<secure-asset-delivery-api-key>",
   // Optional: include or exclude specific entities
   // include: ["contentItems", "assets"],
   // exclude: ["roles"],
+  // Optional: specify secure asset delivery API key
+  // secureAssetDeliveryKey: "<secure-asset-delivery-api-key>",
 };
 
 await backupEnvironment(params);
@@ -231,7 +231,7 @@ await restoreEnvironment(params);
 ### Asset Limitations
 
 - **Asset Size Limit**: The Management API accepts only assets smaller than 100 MB. If your backup file contains assets larger than that (they can be uploaded through the UI), the tool won't be able to import them.
-- **Asset Quality**: Assets fetched by the tool may be compressed and metadata can be missing. You may find more information about asset compression in the [quality](https://kontent.ai/learn/docs/apis/image-transformation-api#a-quality-parameter) and [lossles](https://kontent.ai/learn/docs/apis/image-transformation-api#a-lossless-parameter) parameter documentation.
+- **Asset Quality**: Assets fetched by the tool may be compressed and metadata can be missing. You may find more information about asset compression in the [quality parameter](https://kontent.ai/learn/docs/apis/image-transformation-api#a-quality-parameter) documentation.
 
 ### Performance
 

--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -49,14 +49,15 @@ npx @kontent-ai/data-ops@latest environment backup --help
 
 ### Parameters
 
-| Parameter         | Description                                                                       |
-|-------------------|-----------------------------------------------------------------------------------|
-| `--environmentId` | The ID of the environment you want to backup.                           |
-| `--apiKey`        | The Management API key for the environment.                                       |
-| `--fileName`      | (Optional) The name of the output `.zip` file. Default is `backup.zip`.           |
-| `--include`       | (Optional) Specify entities to include in the backup.                             |
-| `--exclude`       | (Optional) Specify entities to exclude from the backup.                           |
-| `--configFile`    | (Optional) Path to a JSON configuration file containing parameters.               |
+| Parameter                  | Description                                                             |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `--environmentId`          | The ID of the environment you want to backup.                           |
+| `--apiKey`                 | The Management API key for the environment.                             |
+| `--secureAssetDeliveryKey` | (Optional) The secure asset delivery API key for the environment.       |
+| `--fileName`               | (Optional) The name of the output `.zip` file. Default is `backup.zip`. |
+| `--include`                | (Optional) Specify entities to include in the backup.                   |
+| `--exclude`                | (Optional) Specify entities to exclude from the backup.                 |
+| `--configFile`             | (Optional) Path to a JSON configuration file containing parameters.     |
 
 ### Examples
 
@@ -89,6 +90,8 @@ const params: BackupEnvironmentParams = {
   apiKey: "<mapi-key>",
   // Optional: specify output file name
   // fileName: "backup.zip",
+  // Optional: specify secure asset delivery API key
+  // secureAssetDeliveryKey: "<secure-asset-delivery-api-key>",
   // Optional: include or exclude specific entities
   // include: ["contentItems", "assets"],
   // exclude: ["roles"],
@@ -154,14 +157,14 @@ npx @kontent-ai/data-ops@latest environment restore --fileName <file-to-restore>
 
 ### Parameters
 
-| Parameter         | Description                                                                |
-|-------------------|----------------------------------------------------------------------------|
-| `--fileName`      | The path to the `.zip` file containing the data to restore.                 |
-| `--environmentId` | The ID of the target environment where you want to restore data to.            |
-| `--apiKey`        | The Management API key for the target environment.                         |
-| `--include`       | (Optional) Specify entities to restore.                      |
-| `--exclude`       | (Optional) Specify entities to exclude from the restore.                    |
-| `--configFile`    | (Optional) Path to a JSON configuration file containing parameters.        |
+| Parameter         | Description                                                         |
+| ----------------- | ------------------------------------------------------------------- |
+| `--fileName`      | The path to the `.zip` file containing the data to restore.         |
+| `--environmentId` | The ID of the target environment where you want to restore data to. |
+| `--apiKey`        | The Management API key for the target environment.                  |
+| `--include`       | (Optional) Specify entities to restore.                             |
+| `--exclude`       | (Optional) Specify entities to exclude from the restore.            |
+| `--configFile`    | (Optional) Path to a JSON configuration file containing parameters. |
 
 ### Examples
 

--- a/src/commands/environment/backupRestore/backup.ts
+++ b/src/commands/environment/backupRestore/backup.ts
@@ -36,6 +36,11 @@ export const register: RegisterCommand = yargs =>
           demandOption: "You need to provide a Management API key for the given Kontent.ai environment.",
           alias: "k",
         })
+        .option("secureAssetDeliveryKey", {
+          type: "string",
+          describe:
+            "You need to provide a asset delivery key when secure asset delivery is enabled for the given Kontent.ai environment.",
+        })
         .option("include", {
           type: "array",
           describe: "Only back up specified entities.",
@@ -62,6 +67,7 @@ type BackupEnvironmentCliParams =
     environmentId: string;
     fileName: string | undefined;
     apiKey: string;
+    secureAssetDeliveryKey: string | undefined;
     include: ReadonlyArray<BackupEntityChoices> | undefined;
     exclude: ReadonlyArray<BackupEntityChoices> | undefined;
     kontentUrl: string | undefined;

--- a/src/commands/environment/backupRestore/backup.ts
+++ b/src/commands/environment/backupRestore/backup.ts
@@ -39,7 +39,7 @@ export const register: RegisterCommand = yargs =>
         .option("secureAssetDeliveryKey", {
           type: "string",
           describe:
-            "You need to provide a asset delivery key when secure asset delivery is enabled for the given Kontent.ai environment.",
+            "You need to provide a secure asset delivery key when secure asset delivery is enabled for the given Kontent.ai environment.",
         })
         .option("include", {
           type: "array",

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -105,8 +105,8 @@ export const backupEnvironmentInternal = async (
       await (def as EntityDefinition<unknown>).addOtherFiles?.(
         entities,
         archive,
-        params,
         params.secureAssetDeliveryKey,
+        params,
       );
       const result = def.serializeEntities(entities);
 

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -59,6 +59,7 @@ export type BackupEnvironmentParams = Readonly<
     environmentId: string;
     fileName?: string;
     apiKey: string;
+    secureAssetDeliveryKey?: string;
     kontentUrl?: string;
   }
   & IncludeExclude<BackupEntityChoices>
@@ -101,7 +102,12 @@ export const backupEnvironmentInternal = async (
 
     try {
       const entities = await def.fetchEntities(client);
-      await (def as EntityDefinition<unknown>).addOtherFiles?.(entities, archive, params);
+      await (def as EntityDefinition<unknown>).addOtherFiles?.(
+        entities,
+        archive,
+        params,
+        params.secureAssetDeliveryKey,
+      );
       const result = def.serializeEntities(entities);
 
       archive.append(result, { name: `${def.name}.json` });

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -97,17 +97,21 @@ export const backupEnvironmentInternal = async (
   const archive = archiver("zip");
   archive.pipe(outputStream);
 
+  const warnings: { assetWarnings: number } = { assetWarnings: 0 };
   await serially(definitionsToBackup.map(def => async () => {
     logInfo(params, "standard", `Exporting: ${chalk.bold.yellow(def.displayName)}`);
 
     try {
       const entities = await def.fetchEntities(client);
-      await (def as EntityDefinition<unknown>).addOtherFiles?.(
+      const warning = (await (def as EntityDefinition<unknown>).addOtherFiles?.(
         entities,
         archive,
         params,
         params.secureAssetDeliveryKey,
-      );
+      ))?.warnings;
+      if (warning) {
+        warnings.assetWarnings += warning;
+      }
       const result = def.serializeEntities(entities);
 
       archive.append(result, { name: `${def.name}.json` });
@@ -129,7 +133,9 @@ export const backupEnvironmentInternal = async (
     params,
     "standard",
     `\nEntities from environment ${chalk.yellow(params.environmentId)} were ${
-      chalk.green("successfully backuped")
+      warnings.assetWarnings
+        ? chalk.red(`backed up with ${warnings.assetWarnings} warning(s)`)
+        : chalk.green("successfully backed up")
     } into ${chalk.blue(fileName)}.`,
   );
 };

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -97,21 +97,17 @@ export const backupEnvironmentInternal = async (
   const archive = archiver("zip");
   archive.pipe(outputStream);
 
-  const warnings: { assetWarnings: number } = { assetWarnings: 0 };
   await serially(definitionsToBackup.map(def => async () => {
     logInfo(params, "standard", `Exporting: ${chalk.bold.yellow(def.displayName)}`);
 
     try {
       const entities = await def.fetchEntities(client);
-      const warning = (await (def as EntityDefinition<unknown>).addOtherFiles?.(
+      await (def as EntityDefinition<unknown>).addOtherFiles?.(
         entities,
         archive,
         params,
         params.secureAssetDeliveryKey,
-      ))?.warnings;
-      if (warning) {
-        warnings.assetWarnings += warning;
-      }
+      );
       const result = def.serializeEntities(entities);
 
       archive.append(result, { name: `${def.name}.json` });
@@ -133,9 +129,7 @@ export const backupEnvironmentInternal = async (
     params,
     "standard",
     `\nEntities from environment ${chalk.yellow(params.environmentId)} were ${
-      warnings.assetWarnings
-        ? chalk.red(`backed up with ${warnings.assetWarnings} warning(s)`)
-        : chalk.green("successfully backed up")
+      chalk.green("successfully backuped")
     } into ${chalk.blue(fileName)}.`,
   );
 };

--- a/src/modules/backupRestore/backupRestoreEntities/entities/assets.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entities/assets.ts
@@ -24,7 +24,7 @@ export const assetsEntity = {
   fetchEntities: client =>
     client.listAssets().toAllPromise().then(res => res.data.items.map(a => a._raw as AssetWithElements)),
   serializeEntities: JSON.stringify,
-  addOtherFiles: async (assets, archive, logOptions, secureAssetDeliveryKey) => {
+  addOtherFiles: async (assets, archive, secureAssetDeliveryKey, logOptions) => {
     await serially(assets.map(a => () => saveAsset(archive, logOptions, a, secureAssetDeliveryKey)));
   },
   deserializeEntities: JSON.parse,
@@ -72,11 +72,12 @@ const saveAsset = async (
   secureAssetDeliveryKey: string | undefined,
 ) => {
   logInfo(logOptions, "verbose", `Exporting: file ${chalk.yellow(asset.file_name)}.`);
-  const defaultOptions: RequestInit = {
+  const options: RequestInit = {
     headers: secureAssetDeliveryKey ? { Authorization: `Bearer ${secureAssetDeliveryKey}` } : undefined,
   };
-  const file = await fetch(asset.url, defaultOptions)
-    .then(res => res.blob()).then(res => res.stream());
+  const file = await fetch(`${asset.url}?q=100`, options)
+    .then(res => res.blob())
+    .then(res => res.stream());
   archive.append(stream.Readable.fromWeb(file), { name: createFileName(asset) });
 };
 

--- a/src/modules/backupRestore/backupRestoreEntities/entities/assets.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entities/assets.ts
@@ -24,13 +24,9 @@ export const assetsEntity = {
   fetchEntities: client =>
     client.listAssets().toAllPromise().then(res => res.data.items.map(a => a._raw as AssetWithElements)),
   serializeEntities: JSON.stringify,
-  addOtherFiles: async (assets, archive, logOptions, secureAssetDeliveryKey) =>
-    // CONSIDER: Throw an error here if the size of any asset does not match expectations instead of giving a warning on a per asset basis in `saveAsset`.
-    (await serially(assets.map(a => () => saveAsset(archive, logOptions, a, secureAssetDeliveryKey))))
-      .reduce(
-        (prev, curr) => curr.warning ? { warnings: prev.warnings + 1 } : prev,
-        { warnings: 0 },
-      ),
+  addOtherFiles: async (assets, archive, logOptions, secureAssetDeliveryKey) => {
+    await serially(assets.map(a => () => saveAsset(archive, logOptions, a, secureAssetDeliveryKey)));
+  },
   deserializeEntities: JSON.parse,
   importEntities: async (client, fileAssets, context, logOptions, zip) => {
     const fileAssetsWithElements = fileAssets.filter(a => !!a.elements.length);
@@ -75,33 +71,13 @@ const saveAsset = async (
   asset: AssetContracts.IAssetModelContract,
   secureAssetDeliveryKey: string | undefined,
 ) => {
-  let warning = false;
   logInfo(logOptions, "verbose", `Exporting: file ${chalk.yellow(asset.file_name)}.`);
   const defaultOptions: RequestInit = {
     headers: secureAssetDeliveryKey ? { Authorization: `Bearer ${secureAssetDeliveryKey}` } : undefined,
   };
   const file = await fetch(asset.url, defaultOptions)
-    .then(res => res.blob()).then(res => {
-      if (res.size !== asset.size) {
-        warning = true;
-        logInfo(
-          logOptions,
-          "standard",
-          chalk.red(`${
-            chalk.bold(
-              `Size mismatch: expected ${asset.size} bytes, got ${res.size} bytes`,
-            )
-          }${
-            (!logOptions.verbose && logOptions.logLevel !== "none" && logOptions.logLevel !== "verbose")
-              ? ` (${createFileName(asset)})`
-              : ""
-          }.`),
-        );
-      }
-      return res.stream();
-    });
+    .then(res => res.blob()).then(res => res.stream());
   archive.append(stream.Readable.fromWeb(file), { name: createFileName(asset) });
-  return { warning };
 };
 
 const createImportAssetFetcher =

--- a/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
@@ -11,7 +11,12 @@ export type EntityBackupDefinition<T> = Readonly<{
   displayName: string;
   fetchEntities: (client: ManagementClient) => Promise<T>;
   serializeEntities: (entities: T) => string;
-  addOtherFiles?: (loadedEntities: T, archive: archiver.Archiver, logOptions: LogOptions) => Promise<void>;
+  addOtherFiles?: (
+    loadedEntities: T,
+    archive: archiver.Archiver,
+    logOptions: LogOptions,
+    secureAssetDeliveryKey: string | undefined,
+  ) => Promise<void>;
 }>;
 
 export type EntityRestoreDefinition<T> = Readonly<{
@@ -29,11 +34,7 @@ export type EntityRestoreDefinition<T> = Readonly<{
 
 export type EntityCleanDefinition<T> = Readonly<{
   name: string;
-  cleanEntities: (
-    client: ManagementClient,
-    entities: T,
-    logOptions: LogOptions,
-  ) => Promise<void>;
+  cleanEntities: (client: ManagementClient, entities: T, logOptions: LogOptions) => Promise<void>;
 }>;
 
 export type DependentRestoreAction<T> = Readonly<{

--- a/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
@@ -14,8 +14,8 @@ export type EntityBackupDefinition<T> = Readonly<{
   addOtherFiles?: (
     loadedEntities: T,
     archive: archiver.Archiver,
-    logOptions: LogOptions,
     secureAssetDeliveryKey: string | undefined,
+    logOptions: LogOptions,
   ) => Promise<void>;
 }>;
 

--- a/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
@@ -16,7 +16,7 @@ export type EntityBackupDefinition<T> = Readonly<{
     archive: archiver.Archiver,
     logOptions: LogOptions,
     secureAssetDeliveryKey: string | undefined,
-  ) => Promise<void>;
+  ) => Promise<{ warnings: number }>;
 }>;
 
 export type EntityRestoreDefinition<T> = Readonly<{

--- a/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entityDefinition.ts
@@ -16,7 +16,7 @@ export type EntityBackupDefinition<T> = Readonly<{
     archive: archiver.Archiver,
     logOptions: LogOptions,
     secureAssetDeliveryKey: string | undefined,
-  ) => Promise<{ warnings: number }>;
+  ) => Promise<void>;
 }>;
 
 export type EntityRestoreDefinition<T> = Readonly<{


### PR DESCRIPTION
### Motivation

Currently, for environments with [secure assets delivery](https://kontent.ai/learn/docs/security/secure-access/javascript#a-retrieve-assets-securely) enabled, the resulting backup contains assets with a file size of 0 kB in the assets/ folder.

This is critical as for certain users, the backup is incomplete, and no error/warning is provided.

Preposition
Support could be added by providing the bearer token to the fetching of assets.

In addition, this PR adds the quality query parameter `?p=100` to ensure maximum quality during backup.

Only ran unit tests.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Set up a new environment and contact Kontent.ai support to enable secure asset delivery for at least the `delivery API`.

Partially resolves #100 