### PR TITLE
Fix typos

### DIFF
--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -1,6 +1,6 @@
 # Environment Backup & Restore
 
-The `environment backup` and `enviroment restore` environment commands let you easily backup and then restore your Kontent.ai environment.
+The `environment backup` and `environment restore` environment commands let you easily backup and then restore your Kontent.ai environment.
 
 ## Including and Excluding Entities in Environment commands
 

--- a/src/commands/migrateContent/run/run.ts
+++ b/src/commands/migrateContent/run/run.ts
@@ -33,20 +33,20 @@ export const register: RegisterCommand = yargs =>
         })
         .option("sourceEnvironmentId", {
           type: "string",
-          describe: "Id of Kontent.ai environmnent containing source content.",
+          describe: "Id of Kontent.ai environment containing source content.",
           alias: "s",
           implies: ["sourceApiKey"],
         })
         .option("sourceApiKey", {
           type: "string",
-          describe: "Management Api key of Kontent.ai environmnent containing source content.",
+          describe: "Management Api key of Kontent.ai environment containing source content.",
           alias: "sk",
           implies: ["sourceEnvironmentId"],
         })
         .option("sourceDeliveryPreviewKey", {
           type: "string",
           describe:
-            "Delivery Api key of Kontent.ai environmnent containing source content model. Use only when you want obtain codenames via delivery client.",
+            "Delivery Api key of Kontent.ai environment containing source content model. Use only when you want obtain codenames via delivery client.",
           alias: "sd",
         })
         .option("filename", {
@@ -156,32 +156,32 @@ OK to proceed y/n? (suppress this message with --sw parameter)\n`,
 };
 
 const resolveParams = (params: MigrateContentRunCliParams): MigrateContentRunParams => {
-  const ommited = omit(params, ["sourceEnvironmentId", "sourceApiKey", "items", "filter", "last", "byTypesCodenames"]);
+  const omitted = omit(params, ["sourceEnvironmentId", "sourceApiKey", "items", "filter", "last", "byTypesCodenames"]);
 
   if (params.filename) {
-    return { ...ommited, filename: params.filename };
+    return { ...omitted, filename: params.filename };
   }
 
   const filterParams = match(params)
     .with(
       { items: P.nonNullable, depth: P.nonNullable, sourceDeliveryPreviewKey: P.nonNullable },
-      ({ items, depth, sourceDeliveryPreviewKey }) => ({ ...ommited, items, depth, sourceDeliveryPreviewKey }),
+      ({ items, depth, sourceDeliveryPreviewKey }) => ({ ...omitted, items, depth, sourceDeliveryPreviewKey }),
     )
     .with(
       { items: P.nonNullable },
-      ({ items }) => ({ ...ommited, items }),
+      ({ items }) => ({ ...omitted, items }),
     )
     .with(
       { byTypesCodenames: P.nonNullable, sourceDeliveryPreviewKey: P.nonNullable },
-      ({ byTypesCodenames, sourceDeliveryPreviewKey }) => ({ ...ommited, byTypesCodenames, sourceDeliveryPreviewKey }),
+      ({ byTypesCodenames, sourceDeliveryPreviewKey }) => ({ ...omitted, byTypesCodenames, sourceDeliveryPreviewKey }),
     )
     .with(
       { filter: P.nonNullable, sourceDeliveryPreviewKey: P.nonNullable },
-      ({ filter, sourceDeliveryPreviewKey }) => ({ ...ommited, filter, sourceDeliveryPreviewKey }),
+      ({ filter, sourceDeliveryPreviewKey }) => ({ ...omitted, filter, sourceDeliveryPreviewKey }),
     )
     .with(
       { last: P.nonNullable, sourceDeliveryPreviewKey: P.nonNullable },
-      ({ last, sourceDeliveryPreviewKey }) => ({ ...ommited, last, sourceDeliveryPreviewKey }),
+      ({ last, sourceDeliveryPreviewKey }) => ({ ...omitted, last, sourceDeliveryPreviewKey }),
     )
     .otherwise(() => {
       logError(
@@ -193,7 +193,7 @@ const resolveParams = (params: MigrateContentRunCliParams): MigrateContentRunPar
 
   if (params.sourceEnvironmentId && params.sourceApiKey && params.language) {
     return {
-      ...ommited,
+      ...omitted,
       ...filterParams,
       sourceEnvironmentId: params.sourceEnvironmentId,
       sourceApiKey: params.sourceApiKey,

--- a/src/commands/migrateContent/snapshot/snapshot.ts
+++ b/src/commands/migrateContent/snapshot/snapshot.ts
@@ -20,20 +20,20 @@ export const register: RegisterCommand = yargs =>
         yargs
           .option("sourceEnvironmentId", {
             type: "string",
-            describe: "Id of Kontent.ai environmnent containing source content.",
+            describe: "Id of Kontent.ai environment containing source content.",
             demandOption: "You need to provide the environmentId for source Kontent.ai environment.",
             alias: "s",
           })
           .option("sourceApiKey", {
             type: "string",
-            describe: "Management Api key of Kontent.ai environmnent containing source content.",
+            describe: "Management Api key of Kontent.ai environment containing source content.",
             demandOption: "You need to provide a Management API key for source Kontent.ai environment.",
             alias: "sk",
           })
           .option("sourceDeliveryPreviewKey", {
             type: "string",
             describe:
-              "Delivery Preview Api key of Kontent.ai environmnent containing source content. Use only when you want obtain codenames via delivery client.",
+              "Delivery Preview Api key of Kontent.ai environment containing source content. Use only when you want obtain codenames via delivery client.",
             alias: "sd",
           })
           .option("language", {
@@ -68,7 +68,7 @@ export const register: RegisterCommand = yargs =>
           .option("depth", {
             type: "number",
             describe:
-              "Determines the level of linked items in Delivery API response. We encourage using with --limit to prevent hiting upper response limit.",
+              "Determines the level of linked items in Delivery API response. We encourage using with --limit to prevent hitting upper response limit.",
             conflicts: ["filter"],
           })
           .option("limit", {

--- a/src/commands/migrations/run/run.ts
+++ b/src/commands/migrations/run/run.ts
@@ -54,7 +54,7 @@ export const register: RegisterCommand = yargs =>
         })
         .option("all", {
           alias: "a",
-          describe: "Executes all migations.",
+          describe: "Executes all migrations.",
           type: "boolean",
           conflicts: migrationSelectionOptions.filter(o => o !== "all"),
         })
@@ -76,7 +76,7 @@ export const register: RegisterCommand = yargs =>
           type: "string",
         })
         .option("continueOnError", {
-          describe: "Determines whether migrations should continue when an error is encoutered.",
+          describe: "Determines whether migrations should continue when an error is encountered.",
           type: "boolean",
         })
         .option("force", {
@@ -168,7 +168,7 @@ const runMigrationsCli = async (params: RunMigrationsCliParams) => {
       return Promise.reject(migrationsStatus.status);
     }
 
-    logInfo(params, "standard", "Sucessfully migrated.\n");
+    logInfo(params, "standard", "Successfully migrated.\n");
 
     return migrationsStatus.status;
   });

--- a/src/commands/sync/diff/diff.ts
+++ b/src/commands/sync/diff/diff.ts
@@ -2,7 +2,7 @@ import { match, P } from "ts-pattern";
 
 import { logError, LogOptions } from "../../../log.js";
 import { syncEntityChoices, SyncEntityName } from "../../../modules/sync/constants/entities.js";
-import { syncDiffInternal, SyncDiffParamsIntenal } from "../../../modules/sync/diffEnvironments.js";
+import { syncDiffInternal, SyncDiffParamsInternal } from "../../../modules/sync/diffEnvironments.js";
 import { createAdvancedDiffFile, printDiff } from "../../../modules/sync/printDiff.js";
 import { RegisterCommand } from "../../../types/yargs.js";
 import { simplifyErrors } from "../../../utils/error.js";
@@ -35,14 +35,14 @@ export const register: RegisterCommand = yargs =>
         })
         .option("sourceEnvironmentId", {
           type: "string",
-          describe: "Id of Kontent.ai environmnent containing source content model.",
+          describe: "Id of Kontent.ai environment containing source content model.",
           conflicts: "folderName",
           implies: ["sourceApiKey"],
           alias: "s",
         })
         .option("sourceApiKey", {
           type: "string",
-          describe: "Management API key of Kontent.ai environmnent containing source content model.",
+          describe: "Management API key of Kontent.ai environment containing source content model.",
           conflicts: "folderName",
           implies: ["sourceEnvironmentId"],
           alias: "sk",
@@ -57,7 +57,7 @@ export const register: RegisterCommand = yargs =>
           type: "array",
           string: true,
           choices: syncEntityChoices,
-          describe: `Diff specified entties. Allowed entities are: ${syncEntityChoices.join(", ")}`,
+          describe: `Diff specified entities. Allowed entities are: ${syncEntityChoices.join(", ")}`,
         })
         .option("outPath", {
           type: "string",
@@ -108,7 +108,7 @@ const syncDiffCli = async (params: syncDiffCliParams) => {
   }
 };
 
-const resolveParams = (params: syncDiffCliParams): SyncDiffParamsIntenal => {
+const resolveParams = (params: syncDiffCliParams): SyncDiffParamsInternal => {
   const updatedParams = { ...params, entities: params.entities ?? syncEntityChoices };
 
   return match(updatedParams)

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -129,7 +129,7 @@ export const backupEnvironmentInternal = async (
     params,
     "standard",
     `\nEntities from environment ${chalk.yellow(params.environmentId)} were ${
-      chalk.green("successfully backuped")
+      chalk.green("successfully backed up")
     } into ${chalk.blue(fileName)}.`,
   );
 };

--- a/src/modules/migrateContent/migrateContentRun.ts
+++ b/src/modules/migrateContent/migrateContentRun.ts
@@ -105,5 +105,5 @@ export const migrateContentRunInternal = async (
     },
   });
 
-  logInfo(params, "standard", `All items sucessfuly migrated`);
+  logInfo(params, "standard", `All items successfully migrated`);
 };

--- a/src/modules/migrations/add.ts
+++ b/src/modules/migrations/add.ts
@@ -52,7 +52,7 @@ export const addMigration = async (params: AddMigrationParams) => {
   logInfo(
     params,
     "standard",
-    `Migration ${migrationName} has been created sucessfully in ${chalk.blue(saveMigrationPath)}`,
+    `Migration ${migrationName} has been created successfully in ${chalk.blue(saveMigrationPath)}`,
   );
 };
 

--- a/src/modules/migrations/run.ts
+++ b/src/modules/migrations/run.ts
@@ -64,7 +64,7 @@ export const runMigrations = async (params: RunMigrationsParams) => {
       return Promise.reject(migrationsStatus.status);
     }
 
-    logInfo(params, "standard", "Sucessfully migrated.\n");
+    logInfo(params, "standard", "Successfully migrated.\n");
 
     return migrationsStatus.status;
   });
@@ -183,7 +183,7 @@ const updateStatus = async (
   logInfo(
     params,
     "standard",
-    `Status sucessfully stored${
+    `Status successfully stored${
       !params.statusPlugins ? ` in ${chalk.green(path.resolve(params.migrationsFolder, "status.json"))}` : ""
     }.`,
   );

--- a/src/modules/sync/diff.ts
+++ b/src/modules/sync/diff.ts
@@ -212,5 +212,5 @@ const adjustSourceDefaultLanguageCodename = (
 const getDefaultLang = (languages: ReadonlyArray<LanguageSyncModel>) => {
   const defaultLang = languages.find(l => l.is_default);
 
-  return defaultLang ?? throwError(`Language enviroment model does not contain default language`);
+  return defaultLang ?? throwError(`Language environment model does not contain default language`);
 };

--- a/src/modules/sync/diffEnvironments.ts
+++ b/src/modules/sync/diffEnvironments.ts
@@ -28,7 +28,7 @@ export type SyncDiffParams = Readonly<
   & LogOptions
 >;
 
-export type SyncDiffParamsIntenal = Replace<SyncDiffParams, { entities: ReadonlyArray<SyncEntityName> }>;
+export type SyncDiffParamsInternal = Replace<SyncDiffParams, { entities: ReadonlyArray<SyncEntityName> }>;
 
 /**
  * Compares two environments and generates an HTML representation of the differences.
@@ -44,7 +44,7 @@ export const syncDiff = async (params: SyncDiffParams) => {
   return resolveHtmlTemplate(diffHtmlTemplate, { ...diffModel, ...resolvedParams });
 };
 
-export const syncDiffInternal = async (params: SyncDiffParamsIntenal, commandName: string) => {
+export const syncDiffInternal = async (params: SyncDiffParamsInternal, commandName: string) => {
   logInfo(
     params,
     "standard",

--- a/tests/unit/migrations/migrationUtils.test.ts
+++ b/tests/unit/migrations/migrationUtils.test.ts
@@ -54,33 +54,33 @@ describe("filterMigrations", () => {
 });
 
 describe("getMigrationsToSkip", () => {
-  it("Correctly return skipped sucesfully migrated migrations", () => {
-    const enviromnentStatus: ReadonlyArray<MigrationStatus> = [
+  it("Correctly return skipped successfully migrated migrations", () => {
+    const environmentStatus: ReadonlyArray<MigrationStatus> = [
       createMigrationStatus(migrations[0].name, migrations[0].module.order, true, "run"),
       createMigrationStatus(migrations[2].name, migrations[2].module.order, true, "run"),
     ];
 
-    const skippedMigrations = getMigrationsToSkip(enviromnentStatus, migrations, "run");
+    const skippedMigrations = getMigrationsToSkip(environmentStatus, migrations, "run");
 
     expect(skippedMigrations).toStrictEqual([migrations[0], migrations[2]]);
   });
 
-  it("Correctly return skipped sucesfully migrated migrations and does not return not sucessfull migration", () => {
-    const enviromnentStatus: ReadonlyArray<MigrationStatus> = [
+  it("Correctly return skipped successfully migrated migrations and does not return not successful migration", () => {
+    const environmentStatus: ReadonlyArray<MigrationStatus> = [
       createMigrationStatus(migrations[0].name, migrations[0].module.order, true, "run"),
       createMigrationStatus(migrations[2].name, migrations[2].module.order, false, "run"),
     ];
-    const skippedMigrations = getMigrationsToSkip(enviromnentStatus, migrations, "run");
+    const skippedMigrations = getMigrationsToSkip(environmentStatus, migrations, "run");
 
     expect(skippedMigrations).toStrictEqual([migrations[0]]);
   });
 
-  it("Correctly return does not return any migration when operation is oposite", () => {
-    const enviromnentStatus: ReadonlyArray<MigrationStatus> = [
+  it("Correctly return does not return any migration when operation is opposite", () => {
+    const environmentStatus: ReadonlyArray<MigrationStatus> = [
       createMigrationStatus(migrations[0].name, migrations[0].module.order, true, "run"),
       createMigrationStatus(migrations[1].name, migrations[1].module.order, false, "run"),
     ];
-    const skippedMigrations = getMigrationsToSkip(enviromnentStatus, migrations, "rollback");
+    const skippedMigrations = getMigrationsToSkip(environmentStatus, migrations, "rollback");
 
     expect(skippedMigrations).toStrictEqual([migrations[2], migrations[3], migrations[4]]);
   });


### PR DESCRIPTION
### Motivation

Correct spelling in readme, commands, symbols, parameters, and tests.
The second commit addresses a build error, as type inference was missing.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
