### PR TITLE
Fix issue where sync would fail if only provided delete operations for collections.

### DIFF
--- a/src/modules/sync/sync/collections.ts
+++ b/src/modules/sync/sync/collections.ts
@@ -10,7 +10,9 @@ export const syncAddAndReplaceCollections = (
   collections: DiffModel["collections"],
   logOptions: LogOptions,
 ) => {
-  if (!collections.length) {
+  const collectionAddAndReplaceOps = collections.filter(op => op.op !== "remove");
+
+  if (!collectionAddAndReplaceOps.length) {
     logInfo(logOptions, "standard", "No collections to add or update");
     return Promise.resolve();
   }
@@ -19,7 +21,7 @@ export const syncAddAndReplaceCollections = (
 
   return client
     .setCollections()
-    .withData(collections.filter(op => op.op !== "remove").map(transformCollectionsReferences))
+    .withData(collectionAddAndReplaceOps.map(transformCollectionsReferences))
     .toPromise();
 };
 


### PR DESCRIPTION
### Motivation

Fixes an issue where the sync method would fail, when it was only provided delete operations for collections
An empty array of operations would be sent to the Kontent.ai API, resulting in an Axios error.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
Run a sync for collections with only delete operations.