### PR TITLE
docs: add note about Asset Taxonomy Remapper workaround for asset tax…

### DIFF
--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -220,6 +220,7 @@ await restoreEnvironment(params);
 ### Entity Limitations
 
 - **Roles and Asset Types**: Roles and [Asset Types](https://kontent.ai/learn/docs/assets/asset-organization#a-set-up-the-asset-type) are currently not a part of the backup due to API limitations. The tool also cannot set role limitations when restoring workflows.
+- **Asset Type Workaround:** Taxonomy elements on assets are not restored during the backup/restore process, due to current API behavior. A workaround is available via the [Asset Taxonomy Remapper](https://github.com/Kontent-ai-consulting/asset-taxonomy-remap) script. This tool can be run post-restore to remap taxonomy terms on assets by comparing source and target environments using the Management API.
 
 ### Multiple Versions of Content
 


### PR DESCRIPTION
This is a minor update to backupRestore README.md, which provides information and a link to the "Asset Taxonomy Remapper" script. A solution for the Asset Type Known Limitation. 

/commands/environment/backupRestore/README.md