### PR TITLE
Format and lint files with locally linked Biome v2.1.2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["@kontent-ai/biome-config/base"],
   "files": {
-    "ignore": ["package.json"]
+    "includes": ["src/**", "!**/package.json"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
         "data-ops": "build/src/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
-        "@kontent-ai/biome-config": "^0.4.0",
+        "@biomejs/biome": "^2.1.2",
+        "@kontent-ai/biome-config": "^0.5.0",
         "@kontent-ai/eslint-config": "^2.0.0",
         "@types/archiver": "^6.0.3",
         "@types/node": "^22.13.16",
@@ -104,11 +104,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.1.2.tgz",
+      "integrity": "sha512-yq8ZZuKuBVDgAS76LWCfFKHSYIAgqkxVB3mGVVpOe2vSkUTs7xG46zXZeNPRNVjiJuw0SZ3+J2rXiYx0RUpfGg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -121,20 +120,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.1.2",
+        "@biomejs/cli-darwin-x64": "2.1.2",
+        "@biomejs/cli-linux-arm64": "2.1.2",
+        "@biomejs/cli-linux-arm64-musl": "2.1.2",
+        "@biomejs/cli-linux-x64": "2.1.2",
+        "@biomejs/cli-linux-x64-musl": "2.1.2",
+        "@biomejs/cli-win32-arm64": "2.1.2",
+        "@biomejs/cli-win32-x64": "2.1.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-leFAks64PEIjc7MY/cLjE8u5OcfBKkcDB0szxsWUB4aDfemBep1WVKt0qrEyqZBOW8LPHzrFMyDl3FhuuA0E7g==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +148,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.2.tgz",
+      "integrity": "sha512-Nmmv7wRX5Nj7lGmz0FjnWdflJg4zii8Ivruas6PBKzw5SJX/q+Zh2RfnO+bBnuKLXpj8kiI2x2X12otpH6a32A==",
       "cpu": [
         "x64"
       ],
@@ -166,9 +165,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw==",
       "cpu": [
         "arm64"
       ],
@@ -183,9 +182,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.2.tgz",
+      "integrity": "sha512-qgHvafhjH7Oca114FdOScmIKf1DlXT1LqbOrrbR30kQDLFPEOpBG0uzx6MhmsrmhGiCFCr2obDamu+czk+X0HQ==",
       "cpu": [
         "arm64"
       ],
@@ -200,9 +199,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.2.tgz",
+      "integrity": "sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA==",
       "cpu": [
         "x64"
       ],
@@ -217,9 +216,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.2.tgz",
+      "integrity": "sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA==",
       "cpu": [
         "x64"
       ],
@@ -234,9 +233,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.2.tgz",
+      "integrity": "sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA==",
       "cpu": [
         "arm64"
       ],
@@ -251,9 +250,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.2.tgz",
+      "integrity": "sha512-9zajnk59PMpjBkty3bK2IrjUsUHvqe9HWwyAWQBjGLE7MIBjbX2vwv1XPEhmO2RRuGoTkVx3WCanHrjAytICLA==",
       "cpu": [
         "x64"
       ],
@@ -1012,13 +1011,13 @@
       }
     },
     "node_modules/@kontent-ai/biome-config": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@kontent-ai/biome-config/-/biome-config-0.4.0.tgz",
-      "integrity": "sha512-56i1FoLzzFfvbTGlUm8FGrpFqmj6D/r1+PrA/zkAqzzEZHMVI40rbgBxbKiC38gyVsKVhjJXlaYZZAyw0KDEQA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@kontent-ai/biome-config/-/biome-config-0.5.0.tgz",
+      "integrity": "sha512-8gftNrZdU997a6nbixgZj/oxlDz1dYDJCtfmfdmXvtcom9hiKnW3J0IlEvQ79+CocwS/Ah2wNOgJQOqYm/O8pQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@biomejs/biome": "^1.9.4"
+        "@biomejs/biome": "^2.1.2"
       }
     },
     "node_modules/@kontent-ai/core-sdk": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@kontent-ai/biome-config": "^0.4.0",
+    "@biomejs/biome": "^2.1.2",
+    "@kontent-ai/biome-config": "^0.5.0",
     "@kontent-ai/eslint-config": "^2.0.0",
     "@types/archiver": "^6.0.3",
     "@types/node": "^22.13.16",

--- a/src/commands/migrateContent/run/run.ts
+++ b/src/commands/migrateContent/run/run.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError } from "../../../log.js";
 import {

--- a/src/commands/migrateContent/snapshot/snapshot.ts
+++ b/src/commands/migrateContent/snapshot/snapshot.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError } from "../../../log.js";
 import {

--- a/src/commands/migrations/run/run.ts
+++ b/src/commands/migrations/run/run.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError, logInfo } from "../../../log.js";
 import { type RunMigrationsParams, withMigrationsToRun } from "../../../modules/migrations/run.js";

--- a/src/commands/sync/diff/diff.ts
+++ b/src/commands/sync/diff/diff.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError } from "../../../log.js";
 import {

--- a/src/commands/sync/run/run.ts
+++ b/src/commands/sync/run/run.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError } from "../../../log.js";
 import {

--- a/src/modules/backupRestore/backup.ts
+++ b/src/modules/backupRestore/backup.ts
@@ -1,6 +1,5 @@
-import { finished } from "node:stream/promises";
-
 import * as fs from "node:fs";
+import { finished } from "node:stream/promises";
 import type { ManagementClient } from "@kontent-ai/management-sdk";
 import archiver from "archiver";
 import chalk from "chalk";
@@ -16,14 +15,14 @@ import { collectionsEntity } from "./backupRestoreEntities/entities/collections.
 import { contentItemsEntity } from "./backupRestoreEntities/entities/contentItems.js";
 import { contentTypesEntity } from "./backupRestoreEntities/entities/contentTypes.js";
 import { contentTypesSnippetsEntity } from "./backupRestoreEntities/entities/contentTypesSnippets.js";
-import { languageVariantsEntity } from "./backupRestoreEntities/entities/languageVariants.js";
 import { languagesEntity } from "./backupRestoreEntities/entities/languages.js";
+import { languageVariantsEntity } from "./backupRestoreEntities/entities/languageVariants.js";
 import { previewUrlsEntity } from "./backupRestoreEntities/entities/previewUrls.js";
 import { rolesExportEntity } from "./backupRestoreEntities/entities/roles.js";
 import { spacesEntity } from "./backupRestoreEntities/entities/spaces.js";
 import { taxonomiesEntity } from "./backupRestoreEntities/entities/taxonomies.js";
-import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import { webhooksEntity } from "./backupRestoreEntities/entities/webhooks.js";
+import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import { workflowsEntity } from "./backupRestoreEntities/entities/workflows.js";
 import type {
   AnyEntityBackupDefinition,

--- a/src/modules/backupRestore/backupRestoreEntities/entities/contentTypes.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entities/contentTypes.ts
@@ -18,9 +18,9 @@ import type {
   RestoreContext,
 } from "../entityDefinition.js";
 import {
-  type MultiChoiceElement,
   createPatchItemAndTypeReferencesInTypeElement,
   createTransformTypeElement,
+  type MultiChoiceElement,
 } from "./utils/typeElements.js";
 
 type Type = Replace<
@@ -173,7 +173,7 @@ const createMakeTypeContextByOldIdEntry =
     ];
   };
 
-const createInsertTypeFetcher = (params: InsertTypeParams) => (type: Type) => async () => {
+const createInsertTypeFetcher = (params: InsertTypeParams) => (type: Type) => () => {
   logInfo(params.logOptions, "verbose", `Importing: type ${type.id} (${chalk.yellow(type.name)})`);
 
   const makeGroupFallbackExternalId = (groupCodename: string | undefined) =>

--- a/src/modules/backupRestore/backupRestoreEntities/entities/contentTypesSnippets.ts
+++ b/src/modules/backupRestore/backupRestoreEntities/entities/contentTypesSnippets.ts
@@ -16,9 +16,9 @@ import type {
   RestoreContext,
 } from "../entityDefinition.js";
 import {
-  type MultiChoiceElement,
   createPatchItemAndTypeReferencesInTypeElement,
   createTransformTypeElement,
+  type MultiChoiceElement,
 } from "./utils/typeElements.js";
 
 type Snippet = Replace<
@@ -124,38 +124,37 @@ type InsertSnippetParams = Readonly<{
   logOptions: LogOptions;
 }>;
 
-const createInsertSnippetFetcher =
-  (params: InsertSnippetParams) => (snippet: Snippet) => async () => {
-    logInfo(
-      params.logOptions,
-      "verbose",
-      `Importing: snippet ${snippet.id} (${chalk.yellow(snippet.name)})`,
-    );
+const createInsertSnippetFetcher = (params: InsertSnippetParams) => (snippet: Snippet) => () => {
+  logInfo(
+    params.logOptions,
+    "verbose",
+    `Importing: snippet ${snippet.id} (${chalk.yellow(snippet.name)})`,
+  );
 
-    return params.client
-      .addContentTypeSnippet()
-      .withData((builder) => ({
-        name: snippet.name,
-        codename: snippet.codename,
-        external_id: snippet.external_id ?? snippet.codename,
-        elements: snippet.elements.map(
-          createTransformTypeElement({
-            ...params,
-            builder,
-            typeOrSnippetCodename: snippet.codename,
-            elementExternalIdsByOldId: new Map(
-              snippet.elements.map((el) => [
-                el.id,
-                el.external_id ?? `${snippet.codename}_${el.codename}_element`,
-              ]),
-            ),
-            contentGroupExternalIdByOldId: new Map(),
-          }),
-        ),
-      }))
-      .toPromise()
-      .then((res) => res.rawData as Snippet);
-  };
+  return params.client
+    .addContentTypeSnippet()
+    .withData((builder) => ({
+      name: snippet.name,
+      codename: snippet.codename,
+      external_id: snippet.external_id ?? snippet.codename,
+      elements: snippet.elements.map(
+        createTransformTypeElement({
+          ...params,
+          builder,
+          typeOrSnippetCodename: snippet.codename,
+          elementExternalIdsByOldId: new Map(
+            snippet.elements.map((el) => [
+              el.id,
+              el.external_id ?? `${snippet.codename}_${el.codename}_element`,
+            ]),
+          ),
+          contentGroupExternalIdByOldId: new Map(),
+        }),
+      ),
+    }))
+    .toPromise()
+    .then((res) => res.rawData as Snippet);
+};
 
 type UpdateSnippetParams = Readonly<{
   client: ManagementClient;

--- a/src/modules/backupRestore/clean.ts
+++ b/src/modules/backupRestore/clean.ts
@@ -15,8 +15,8 @@ import { languagesEntity } from "./backupRestoreEntities/entities/languages.js";
 import { previewUrlsEntity } from "./backupRestoreEntities/entities/previewUrls.js";
 import { spacesEntity } from "./backupRestoreEntities/entities/spaces.js";
 import { taxonomiesEntity } from "./backupRestoreEntities/entities/taxonomies.js";
-import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import { webhooksEntity } from "./backupRestoreEntities/entities/webhooks.js";
+import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import { workflowsEntity } from "./backupRestoreEntities/entities/workflows.js";
 import type {
   AnyEntityCleanDefinition,

--- a/src/modules/backupRestore/restore.ts
+++ b/src/modules/backupRestore/restore.ts
@@ -17,13 +17,13 @@ import {
   contentTypesSnippetsEntity,
   updateItemAndTypeReferencesInSnippetsImportEntity,
 } from "./backupRestoreEntities/entities/contentTypesSnippets.js";
-import { languageVariantsEntity } from "./backupRestoreEntities/entities/languageVariants.js";
 import { languagesEntity } from "./backupRestoreEntities/entities/languages.js";
+import { languageVariantsEntity } from "./backupRestoreEntities/entities/languageVariants.js";
 import { previewUrlsEntity } from "./backupRestoreEntities/entities/previewUrls.js";
 import { spacesEntity } from "./backupRestoreEntities/entities/spaces.js";
 import { taxonomiesEntity } from "./backupRestoreEntities/entities/taxonomies.js";
-import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import { webhooksEntity } from "./backupRestoreEntities/entities/webhooks.js";
+import { webSpotlightEntity } from "./backupRestoreEntities/entities/webSpotlight.js";
 import {
   importWorkflowScopesEntity,
   workflowsEntity,

--- a/src/modules/backupRestore/utils/includeExclude.ts
+++ b/src/modules/backupRestore/utils/includeExclude.ts
@@ -1,4 +1,4 @@
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 export type IncludeExclude<Choices extends string> = Readonly<
   | { include?: ReadonlyArray<Choices>; exclude?: undefined }

--- a/src/modules/migrateContent/migrateContent.ts
+++ b/src/modules/migrateContent/migrateContent.ts
@@ -4,7 +4,7 @@ import type {
   IContentItemElements,
   Responses,
 } from "@kontent-ai/delivery-sdk";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { notNullOrUndefined } from "../../utils/typeguards.js";
 import type { SuperiorOmit } from "../../utils/types.js";
@@ -22,7 +22,7 @@ type SyncContentFilterDeliveryOnlyParams =
 // { items: ReadonlyArray<string>; depth: number; limit?: number } is assignable to { items: ReadonlyArray<string> }
 // therefore it was also removed by Exclude
 
-export const getItemsCodenames = async (
+export const getItemsCodenames = (
   client: DeliveryClient,
   params: SyncContentFilterDeliveryOnlyParams,
 ) => {

--- a/src/modules/migrations/run.ts
+++ b/src/modules/migrations/run.ts
@@ -13,7 +13,7 @@ import type {
   Status,
   StatusPlugin,
 } from "./models/status.js";
-import { type WithErr, handleErr } from "./utils/errUtils.js";
+import { handleErr, type WithErr } from "./utils/errUtils.js";
 import {
   executeMigrations,
   filterMigrations,

--- a/src/modules/migrations/utils/migrationUtils.ts
+++ b/src/modules/migrations/utils/migrationUtils.ts
@@ -4,16 +4,16 @@ import { pathToFileURL } from "node:url";
 
 import type { ManagementClient } from "@kontent-ai/management-sdk";
 import chalk from "chalk";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError, logInfo } from "../../../log.js";
 import { DateLevel, serializeDateForFileName } from "../../../utils/files.js";
 import { seriallyReduce } from "../../../utils/requests.js";
 import {
+  isMigrationModule,
   type Migration,
   type MigrationModuleType,
   type MigrationOrder,
-  isMigrationModule,
 } from "../models/migration.js";
 import type { MigrationOperation, MigrationStatus } from "../models/status.js";
 import type { RunMigrationFilterParams } from "../run.js";

--- a/src/modules/sync/diff/assetFolder.ts
+++ b/src/modules/sync/diff/assetFolder.ts
@@ -1,5 +1,5 @@
 import type { AssetFolderSyncModel } from "../types/syncModel.js";
-import { type Handler, baseHandler, makeArrayHandler, makeObjectHandler } from "./combinators.js";
+import { baseHandler, type Handler, makeArrayHandler, makeObjectHandler } from "./combinators.js";
 
 const assetFolderHandler: Handler<AssetFolderSyncModel> = makeObjectHandler({
   name: baseHandler,

--- a/src/modules/sync/diff/collection.ts
+++ b/src/modules/sync/diff/collection.ts
@@ -1,7 +1,7 @@
 import type { CollectionSyncModel } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
+  type Handler,
   makeArrayHandler,
   makeObjectHandler,
   makeOrderingHandler,

--- a/src/modules/sync/diff/contentType.ts
+++ b/src/modules/sync/diff/contentType.ts
@@ -1,13 +1,13 @@
 import type { PatchOperation } from "../types/patchOperation.js";
 import {
   type ContentTypeSyncModel,
-  type SyncGuidelinesElement,
   isSyncCustomElement,
   isSyncUrlSlugElement,
+  type SyncGuidelinesElement,
 } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
+  type Handler,
   makeAdjustOperationHandler,
   makeArrayHandler,
   makeObjectHandler,

--- a/src/modules/sync/diff/contentTypeSnippet.ts
+++ b/src/modules/sync/diff/contentTypeSnippet.ts
@@ -1,12 +1,12 @@
 import type { PatchOperation } from "../types/patchOperation.js";
 import {
   type ContentTypeSnippetsSyncModel,
-  type SyncGuidelinesElement,
   isSyncCustomElement,
+  type SyncGuidelinesElement,
 } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
+  type Handler,
   makeAdjustOperationHandler,
   makeArrayHandler,
   makeObjectHandler,

--- a/src/modules/sync/diff/language.ts
+++ b/src/modules/sync/diff/language.ts
@@ -1,8 +1,8 @@
 import type { LanguageSyncModel } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
   constantHandler,
+  type Handler,
   makeLeafObjectHandler,
   makeObjectHandler,
   makeWholeObjectsHandler,

--- a/src/modules/sync/diff/modelElements.ts
+++ b/src/modules/sync/diff/modelElements.ts
@@ -23,9 +23,9 @@ import type {
   SyncUrlSlugElement,
 } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
   constantHandler,
+  type Handler,
   makeAdjustOperationHandler,
   makeArrayHandler,
   makeBaseArrayHandler,
@@ -35,9 +35,9 @@ import {
   optionalHandler,
 } from "./combinators.js";
 import {
-  type OriginalReference,
   getAssetReferences,
   getItemReferences,
+  type OriginalReference,
   replaceAssetReferences,
   replaceItemReferences,
 } from "./guidelinesRichText.js";

--- a/src/modules/sync/diff/space.ts
+++ b/src/modules/sync/diff/space.ts
@@ -1,8 +1,8 @@
 import { zip } from "../../../utils/array.js";
 import type { SpaceSyncModel } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
+  type Handler,
   makeLeafObjectHandler,
   makeObjectHandler,
   makeWholeObjectsHandler,

--- a/src/modules/sync/diff/taxonomy.ts
+++ b/src/modules/sync/diff/taxonomy.ts
@@ -2,12 +2,12 @@ import { zip } from "../../../utils/array.js";
 import { throwError } from "../../../utils/error.js";
 import { omit } from "../../../utils/object.js";
 import type { Replace } from "../../../utils/types.js";
-import { type PatchOperation, getTargetCodename } from "../types/patchOperation.js";
+import { getTargetCodename, type PatchOperation } from "../types/patchOperation.js";
 import type { TaxonomySyncModel } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
   constantHandler,
+  type Handler,
   makeAdjustEntityHandler,
   makeAdjustOperationHandler,
   makeArrayHandler,

--- a/src/modules/sync/diff/workflow.ts
+++ b/src/modules/sync/diff/workflow.ts
@@ -1,9 +1,9 @@
 import { zip } from "../../../utils/array.js";
 import type { WorkflowStepSyncModel, WorkflowSyncModel } from "../types/syncModel.js";
 import {
-  type Handler,
   baseHandler,
   constantHandler,
+  type Handler,
   makeAdjustEntityHandler,
   makeArrayHandler,
   makeLeafObjectHandler,

--- a/src/modules/sync/sync/assetFolders.ts
+++ b/src/modules/sync/sync/assetFolders.ts
@@ -7,7 +7,7 @@ import { apply, not } from "../../../utils/function.js";
 import { omit } from "../../../utils/object.js";
 import { serially } from "../../../utils/requests.js";
 import type { DiffModel } from "../types/diffModel.js";
-import { type PatchOperation, getTargetCodename } from "../types/patchOperation.js";
+import { getTargetCodename, type PatchOperation } from "../types/patchOperation.js";
 import { isOp } from "./utils.js";
 
 export const syncAssetFolders = async (

--- a/src/modules/sync/sync/collections.ts
+++ b/src/modules/sync/sync/collections.ts
@@ -3,7 +3,7 @@ import type { CollectionModels, ManagementClient } from "@kontent-ai/management-
 import { type LogOptions, logInfo } from "../../../log.js";
 import { omit } from "../../../utils/object.js";
 import type { DiffModel } from "../types/diffModel.js";
-import { type PatchOperation, getTargetCodename } from "../types/patchOperation.js";
+import { getTargetCodename, type PatchOperation } from "../types/patchOperation.js";
 
 export const syncAddAndReplaceCollections = (
   client: ManagementClient,

--- a/src/modules/sync/sync/snippets.ts
+++ b/src/modules/sync/sync/snippets.ts
@@ -11,11 +11,11 @@ import { elementTypes } from "../constants/elements.js";
 import type { DiffModel } from "../types/diffModel.js";
 import type { PatchOperation } from "../types/patchOperation.js";
 import {
-  type ReferencingElement,
   createUpdateReferenceOps,
   createUpdateReferencesOps,
   isOp,
   isReferencingElement,
+  type ReferencingElement,
   removeReferencesFromAddOp,
 } from "./utils.js";
 

--- a/src/modules/sync/sync/spaces.ts
+++ b/src/modules/sync/sync/spaces.ts
@@ -1,5 +1,5 @@
 import type { ManagementClient, SpaceModels } from "@kontent-ai/management-sdk";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logInfo } from "../../../log.js";
 import { throwError } from "../../../utils/error.js";

--- a/src/modules/sync/sync/taxonomy.ts
+++ b/src/modules/sync/sync/taxonomy.ts
@@ -3,7 +3,7 @@ import type { ManagementClient, TaxonomyModels } from "@kontent-ai/management-sd
 import { type LogOptions, logInfo } from "../../../log.js";
 import { serially } from "../../../utils/requests.js";
 import type { DiffModel } from "../types/diffModel.js";
-import { type PatchOperation, getTargetCodename } from "../types/patchOperation.js";
+import { getTargetCodename, type PatchOperation } from "../types/patchOperation.js";
 
 export const syncTaxonomies = async (
   client: ManagementClient,

--- a/src/modules/sync/sync/webSpotlight.ts
+++ b/src/modules/sync/sync/webSpotlight.ts
@@ -1,5 +1,5 @@
 import type { ManagementClient } from "@kontent-ai/management-sdk";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 
 import { type LogOptions, logInfo } from "../../../log.js";
 import type { WebSpotlightDiffModel } from "../types/diffModel.js";

--- a/src/modules/sync/utils/consoleHelpers.ts
+++ b/src/modules/sync/utils/consoleHelpers.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 
 import { type LogOptions, logInfo } from "../../../log.js";
 
-const requestConfirmation = async (message: string) => {
+const requestConfirmation = (message: string) => {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/src/modules/sync/utils/contentTypeHelpers.ts
+++ b/src/modules/sync/utils/contentTypeHelpers.ts
@@ -7,9 +7,9 @@ import {
 
 import { notNullOrUndefined } from "../../../utils/typeguards.js";
 import {
-  type OriginalReference,
   getAssetReferences,
   getItemReferences,
+  type OriginalReference,
 } from "../diff/guidelinesRichText.js";
 import type {
   SyncAssetElement,

--- a/src/modules/sync/validation.ts
+++ b/src/modules/sync/validation.ts
@@ -13,7 +13,7 @@ import {
 } from "./constants/filename.js";
 import type { ElementsTypes } from "./types/contractModels.js";
 import type { DiffModel } from "./types/diffModel.js";
-import { type PatchOperation, getTargetCodename } from "./types/patchOperation.js";
+import { getTargetCodename, type PatchOperation } from "./types/patchOperation.js";
 
 export const validateSyncModelFolder = async (folderPath: string) => {
   const stats = await fs.stat(folderPath);

--- a/src/modules/sync/validation/entitySchema.ts
+++ b/src/modules/sync/validation/entitySchema.ts
@@ -17,8 +17,8 @@ import type {
 import { CodenameReferenceSchema } from "./commonSchemas.js";
 import {
   SnippetElementsSchemasUnion,
-  TypeElementWithGroupSchemasUnion,
   TypeElementsSchemasUnion,
+  TypeElementWithGroupSchemasUnion,
 } from "./elementSchemas.js";
 
 export const AssetFolderSchema: z.ZodType<AssetFolderSyncModel> = z.strictObject({

--- a/src/public.ts
+++ b/src/public.ts
@@ -1,9 +1,17 @@
 // biome-ignore lint/performance/noBarrelFile: One barrel for the public API is fine
-export { backupEnvironment, BackupEnvironmentParams } from "./modules/backupRestore/backup.js";
-export { cleanEnvironment, CleanEnvironmentParams } from "./modules/backupRestore/clean.js";
-export { restoreEnvironment, RestoreEnvironmentParams } from "./modules/backupRestore/restore.js";
-
-export { addMigration, AddMigrationParams } from "./modules/migrations/add.js";
+export { BackupEnvironmentParams, backupEnvironment } from "./modules/backupRestore/backup.js";
+export { CleanEnvironmentParams, cleanEnvironment } from "./modules/backupRestore/clean.js";
+export { RestoreEnvironmentParams, restoreEnvironment } from "./modules/backupRestore/restore.js";
+export {
+  MigrateContentFilterParams as SyncContentFilterParams,
+  MigrateContentRunParams as SyncContentRunParams,
+  migrateContentRun,
+} from "./modules/migrateContent/migrateContentRun.js";
+export {
+  MigrateContentSnapshotParams,
+  migrateContentSnapshot,
+} from "./modules/migrateContent/migrateContentSnapshot.js";
+export { AddMigrationParams, addMigration } from "./modules/migrations/add.js";
 export { MigrationModule, MigrationOrder } from "./modules/migrations/models/migration.js";
 export {
   MigrationStatus,
@@ -13,13 +21,12 @@ export {
 } from "./modules/migrations/models/status.js";
 export {
   RunMigrationFilterParams,
-  runMigrations,
   RunMigrationsParams,
+  runMigrations,
 } from "./modules/migrations/run.js";
-
-export { syncDiff, SyncDiffParams } from "./modules/sync/diffEnvironments.js";
-export { SyncEntities, syncRun, SyncRunParams } from "./modules/sync/syncRun.js";
-export { syncSnapshot, SyncSnapshotParams } from "./modules/sync/syncSnapshot.js";
+export { SyncDiffParams, syncDiff } from "./modules/sync/diffEnvironments.js";
+export { SyncEntities, SyncRunParams, syncRun } from "./modules/sync/syncRun.js";
+export { SyncSnapshotParams, syncSnapshot } from "./modules/sync/syncSnapshot.js";
 export {
   AssetFolderSyncModel,
   CollectionSyncModel,
@@ -32,13 +39,3 @@ export {
   TaxonomySyncModel,
   WebSpotlightSyncModel,
 } from "./modules/sync/types/syncModel.js";
-
-export {
-  MigrateContentFilterParams as SyncContentFilterParams,
-  migrateContentRun,
-  MigrateContentRunParams as SyncContentRunParams,
-} from "./modules/migrateContent/migrateContentRun.js";
-export {
-  migrateContentSnapshot,
-  MigrateContentSnapshotParams,
-} from "./modules/migrateContent/migrateContentSnapshot.js";

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,5 +1,5 @@
 import { HttpService, type IRetryStrategyOptions, retryHelper } from "@kontent-ai/core-sdk";
-import { type DeliveryClient, createDeliveryClient } from "@kontent-ai/delivery-sdk";
+import { createDeliveryClient, type DeliveryClient } from "@kontent-ai/delivery-sdk";
 import { ManagementClient } from "@kontent-ai/management-sdk";
 import { isAxiosError } from "axios";
 

--- a/tests/integration/backupRestore/clean.test.ts
+++ b/tests/integration/backupRestore/clean.test.ts
@@ -107,7 +107,7 @@ describe("clean command", () => {
     }),
   );
 
-  it.concurrent("Errors when removing types with existing items, prints message.", async () => {
+  it.concurrent("Errors when removing types with existing items, prints message.", () => {
     withTestEnvironment(EXPORT_IMPORT_TEST_DATA_ENVIRONMENT_ID, async (environmentId) => {
       const command = `environment clean -e=${environmentId} -k=${API_KEY} --include contentTypes -s`;
 

--- a/tests/integration/backupRestore/utils/envData.ts
+++ b/tests/integration/backupRestore/utils/envData.ts
@@ -12,8 +12,8 @@ import {
   type RoleContracts,
   type SpaceContracts,
   type TaxonomyContracts,
-  type WebSpotlightContracts,
   type WebhookContracts,
+  type WebSpotlightContracts,
   type WorkflowContracts,
 } from "@kontent-ai/management-sdk";
 import { config as dotenvConfig } from "dotenv";

--- a/tests/unit/migrations/statusUtils.test.ts
+++ b/tests/unit/migrations/statusUtils.test.ts
@@ -1,7 +1,6 @@
-import * as fsPromises from "node:fs/promises";
-import { type MockedObject, describe, expect, it, vitest } from "vitest";
-
 import type { Stats } from "node:fs";
+import * as fsPromises from "node:fs/promises";
+import { describe, expect, it, type MockedObject, vitest } from "vitest";
 import type { MigrationStatus } from "../../../src/modules/migrations/models/status.ts";
 import {
   createDefaultReadStatus,

--- a/tests/unit/syncModel/diff/combinators.test.ts
+++ b/tests/unit/syncModel/diff/combinators.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vitest } from "vitest";
 
 import {
-  type Handler,
   baseHandler,
   constantHandler,
+  type Handler,
   makeAdjustEntityHandler,
   makeAdjustOperationHandler,
   makeArrayHandler,

--- a/tests/unit/syncModel/diff/htmlRenderers.test.ts
+++ b/tests/unit/syncModel/diff/htmlRenderers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import type { PatchOperation } from "../../../../src/modules/sync/types/patchOperation.js";
-import { resolveHtmlTemplate } from "../../../../src/modules/sync/utils/htmlRenderers.js";
 import type { DiffData } from "../../../../src/modules/sync/utils/htmlRenderers.js";
+import { resolveHtmlTemplate } from "../../../../src/modules/sync/utils/htmlRenderers.js";
 
 // Helper function to create empty entity sections with consistent structure
 const createEmptyEntitySection = () => ({

--- a/tests/unit/syncModel/diff/language.test.ts
+++ b/tests/unit/syncModel/diff/language.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
-
-import { type DiffParams, diff } from "../../../../src/modules/sync/diff.js";
 import { languageHandler } from "../../../../src/modules/sync/diff/language.js";
+import { type DiffParams, diff } from "../../../../src/modules/sync/diff.js";
 import type { FileContentModel } from "../../../../src/modules/sync/types/fileContentModel.js";
 import type { PatchOperation } from "../../../../src/modules/sync/types/patchOperation.js";
 import type { LanguageSyncModel } from "../../../../src/modules/sync/types/syncModel.js";


### PR DESCRIPTION
## Summary
- Updated Biome from v1.9.4 to v2.1.2
- Formatted all source files according to the new version's rules
- Primary changes affect import statement ordering and minor code style adjustments

## Test plan
- [ ] Verify that all tests pass
- [ ] Ensure linting runs successfully with the new Biome version
- [ ] Confirm no functional changes were introduced