### PR TITLE
Migrate Content & Sync Run Suppress message fix

### DIFF
--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -220,7 +220,6 @@ await restoreEnvironment(params);
 ### Entity Limitations
 
 - **Roles and Asset Types**: Roles and [Asset Types](https://kontent.ai/learn/docs/assets/asset-organization#a-set-up-the-asset-type) are currently not a part of the backup due to API limitations. The tool also cannot set role limitations when restoring workflows.
-- **Asset Type Workaround:** Taxonomy elements on assets are not restored during the backup/restore process, due to current API behavior. A workaround is available via the [Asset Taxonomy Remapper](https://github.com/Kontent-ai-consulting/asset-taxonomy-remap) script. This tool can be run post-restore to remap taxonomy terms on assets by comparing source and target environments using the Management API.
 
 ### Multiple Versions of Content
 

--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -220,6 +220,7 @@ await restoreEnvironment(params);
 ### Entity Limitations
 
 - **Roles and Asset Types**: Roles and [Asset Types](https://kontent.ai/learn/docs/assets/asset-organization#a-set-up-the-asset-type) are currently not a part of the backup due to API limitations. The tool also cannot set role limitations when restoring workflows.
+- **Asset Type Workaround:** Taxonomy elements on assets are not restored during the backup/restore process, due to current API behavior. A workaround is available via the [Asset Taxonomy Remapper](https://github.com/Kontent-ai-consulting/asset-taxonomy-remap) script. This tool can be run post-restore to remap taxonomy terms on assets by comparing source and target environments using the Management API.
 
 ### Multiple Versions of Content
 

--- a/src/commands/migrateContent/run/run.ts
+++ b/src/commands/migrateContent/run/run.ts
@@ -105,6 +105,7 @@ export const register: RegisterCommand = (yargs) =>
         .option("skipConfirmation", {
           type: "boolean",
           describe: "Skip confirmation message.",
+          alias: "s",
         })
         .option("kontentUrl", {
           type: "string",
@@ -149,7 +150,7 @@ const migrateContentRunCli = async (params: MigrateContentRunCliParams) => {
   await migrateContentRunInternal(resolvedParams, "migrate-content-run", async () => {
     await checkConfirmation({
       message: `⚠ Running this operation may result in irreversible changes to the content in environment ${params.targetEnvironmentId}. 
-OK to proceed y/n? (suppress this message with --sw parameter)\n`,
+OK to proceed y/n? (suppress this message with --s parameter)\n`,
       skipConfirmation: params.skipConfirmation,
       logOptions: params,
     });

--- a/src/commands/sync/run/run.ts
+++ b/src/commands/sync/run/run.ts
@@ -70,6 +70,7 @@ export const register: RegisterCommand = (yargs) =>
         .option("skipConfirmation", {
           type: "boolean",
           describe: "Skip confirmation message.",
+          alias: "s",
         })
         .option("kontentUrl", {
           type: "string",
@@ -100,7 +101,7 @@ const syncRunCli = async (params: SyncModelRunCliParams) => {
       await checkConfirmation({
         message: `⚠ Running this operation may result in irreversible changes to the content in environment ${params.targetEnvironmentId}. Mentioned changes might include:
 - Removing content due to element deletion
-OK to proceed y/n? (suppress this message with --sw parameter)\n`,
+OK to proceed y/n? (suppress this message with --s parameter)\n`,
         skipConfirmation: params.skipConfirmation,
         logOptions: params,
       });


### PR DESCRIPTION
### Motivation

Which issue does this fix? 
New-found issue. 

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

Migrate Content & Sync Run suppress message flag (--sw) was incorrect (eg. suppress this message with --sw parameter) and did not match the suppress command flags for each command (eg. skipConfirmation). Migrate Content & Sync Run suppress flags and messages have been updated to match the Clean command (eg. --s)

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

When using the Migrate Content & Sync Run, the suppress flag has been updated from m--sw to --s. An alias for each command has also been created.   