### PR TITLE
Migrate Content & Sync Run suppress message flag (--sw) was incorrect.

### DIFF
--- a/src/commands/migrateContent/run/README.md
+++ b/src/commands/migrateContent/run/README.md
@@ -115,6 +115,7 @@ The command provides several parameters to cover various scenarios for selecting
 | `--depth`                            | (Optional) The depth of linked items to include in the migration.                                                          |
 | `--limit`                            | (Optional) The maximum number of content items to retrieve per API call (default is 100, maximum is 100).                        |
 | `--configFile`                       | (Optional) Path to a JSON configuration file containing parameters.                                                              |
+| `--skipConfirmation`                 | (Optional) Skip confirmation message.                                                              |
 
 To see all supported parameters, run:
 

--- a/src/commands/migrateContent/run/run.ts
+++ b/src/commands/migrateContent/run/run.ts
@@ -105,6 +105,7 @@ export const register: RegisterCommand = (yargs) =>
         .option("skipConfirmation", {
           type: "boolean",
           describe: "Skip confirmation message.",
+          alias: "sc",
         })
         .option("kontentUrl", {
           type: "string",
@@ -149,7 +150,7 @@ const migrateContentRunCli = async (params: MigrateContentRunCliParams) => {
   await migrateContentRunInternal(resolvedParams, "migrate-content-run", async () => {
     await checkConfirmation({
       message: `⚠ Running this operation may result in irreversible changes to the content in environment ${params.targetEnvironmentId}. 
-OK to proceed y/n? (suppress this message with --sw parameter)\n`,
+OK to proceed y/n? (suppress this message with --sc parameter)\n`,
       skipConfirmation: params.skipConfirmation,
       logOptions: params,
     });

--- a/src/commands/sync/run/run.ts
+++ b/src/commands/sync/run/run.ts
@@ -70,6 +70,7 @@ export const register: RegisterCommand = (yargs) =>
         .option("skipConfirmation", {
           type: "boolean",
           describe: "Skip confirmation message.",
+          alias: "sc",
         })
         .option("kontentUrl", {
           type: "string",
@@ -100,7 +101,7 @@ const syncRunCli = async (params: SyncModelRunCliParams) => {
       await checkConfirmation({
         message: `⚠ Running this operation may result in irreversible changes to the content in environment ${params.targetEnvironmentId}. Mentioned changes might include:
 - Removing content due to element deletion
-OK to proceed y/n? (suppress this message with --sw parameter)\n`,
+OK to proceed y/n? (suppress this message with --sc parameter)\n`,
         skipConfirmation: params.skipConfirmation,
         logOptions: params,
       });


### PR DESCRIPTION
Migrate Content & Sync Run suppress message flag (--sw) was incorrect. (eg. suppress this message with --sw parameter) and did not match the suppress command flags for each command (eg. skipConfirmation). Migrate Content & Sync Run suppress flags and messages have been updated to match the Clean command (eg. --s)
