### PR TITLE
New migrate content option: Tolerate Missing References

### DIFF
--- a/src/commands/migrateContent/run/README.md
+++ b/src/commands/migrateContent/run/README.md
@@ -141,6 +141,7 @@ const params: MigrateContentRunParams = {
   items: ["article1", "article2"],
   // depth: 2,
   // limit: 100,
+  // tolerateMissingReferences: true,
 };
 
 await migrateContentRun(params);

--- a/src/commands/migrateContent/run/README.md
+++ b/src/commands/migrateContent/run/README.md
@@ -114,6 +114,7 @@ The command provides several parameters to cover various scenarios for selecting
 | `--filter`                           | (Mutually exclusive) A custom query string for filtering content items via the Delivery API.                                     |
 | `--depth`                            | (Optional) The depth of linked items to include in the migration.                                                          |
 | `--limit`                            | (Optional) The maximum number of content items to retrieve per API call (default is 100, maximum is 100).                        |
+| `--tolerateMissingReferences`        | (Optional) When enabled, missing items and assets will be skipped instead of throwing errors (default is false).                 |
 | `--configFile`                       | (Optional) Path to a JSON configuration file containing parameters.                                                              |
 | `--skipConfirmation`                 | (Optional) Skip confirmation message.                                                              |
 

--- a/src/commands/migrateContent/run/run.ts
+++ b/src/commands/migrateContent/run/run.ts
@@ -96,6 +96,11 @@ export const register: RegisterCommand = (yargs) =>
           type: "boolean",
           describe: "Continue when encounter the item that can't be migrated.",
         })
+        .option("tolerateMissingReferences", {
+          type: "boolean",
+          describe:
+            "When enabled, missing items and assets will be skipped instead of throwing errors.",
+        })
         .option("filter", {
           type: "string",
           describe:
@@ -139,6 +144,7 @@ type MigrateContentRunCliParams = Readonly<{
   byTypesCodenames: ReadonlyArray<string> | undefined;
   filter: string | undefined;
   skipFailedItems: boolean | undefined;
+  tolerateMissingReferences: boolean | undefined;
   skipConfirmation: boolean | undefined;
   kontentUrl: string | undefined;
 }> &

--- a/src/commands/migrateContent/snapshot/README.md
+++ b/src/commands/migrateContent/snapshot/README.md
@@ -93,6 +93,7 @@ The command provides several parameters to cover various scenarios for selecting
 | `--filter`                         | (Mutually exclusive) A custom query string for filtering content items via the Delivery API.                                                      |
 | `--depth`                          | (Optional) The depth of linked items to include in the export.                                                                                    |
 | `--limit`                          | (Optional) The maximum number of content items to retrieve per API call (default is 100, maximum is 100).                                          |
+| `--tolerateMissingReferences`      | (Optional) When enabled, missing items and assets will be skipped instead of throwing errors (default is false).                                  |
 | `--sourceDeliveryPreviewKey`, `--sd` | The Delivery Preview API key for the source environment. Required when using parameters that utilize the Delivery API.                           |
 | `--configFile`                     | (Optional) Path to a JSON configuration file containing parameters.                                                                              |
 | `--fileName`                       | (Optional) The name of the output file. Default is `contentExport.zip`.                                                                           |

--- a/src/commands/migrateContent/snapshot/snapshot.ts
+++ b/src/commands/migrateContent/snapshot/snapshot.ts
@@ -83,6 +83,11 @@ export const register: RegisterCommand = (yargs) =>
             "A filter to obtain a subset of items codenames. See Delivery API documentation for more information.",
           conflicts: itemsFilterParams.filter((p) => p !== "filter"),
         })
+        .option("tolerateMissingReferences", {
+          type: "boolean",
+          describe:
+            "When enabled, missing items and assets will be skipped instead of throwing errors.",
+        })
         .option("skipConfirmation", {
           type: "boolean",
           describe: "Skip confirmation message.",
@@ -106,6 +111,7 @@ type MigrateContentSnapshotCliParams = Readonly<{
   limit: number | undefined;
   byTypesCodenames: ReadonlyArray<string> | undefined;
   filter: string | undefined;
+  tolerateMissingReferences: boolean | undefined;
   skipConfirmation: boolean | undefined;
   kontentUrl: string | undefined;
 }> &

--- a/src/modules/migrateContent/migrateContentRun.ts
+++ b/src/modules/migrateContent/migrateContentRun.ts
@@ -97,9 +97,7 @@ export const migrateContentRunInternal = async (
       apiKey: params.sourceApiKey,
       items: itemsCodenames.map((i) => ({ itemCodename: i, languageCodename: params.language })),
       baseUrl: apply(createManagementApiUrl, params.kontentUrl),
-      exportOptions: {
-        tolerateMissingReferences: params.tolerateMissingReferences ?? false,
-      },
+      tolerateMissingReferences: params.tolerateMissingReferences ?? false,
     },
   });
 

--- a/src/modules/migrateContent/migrateContentRun.ts
+++ b/src/modules/migrateContent/migrateContentRun.ts
@@ -10,6 +10,7 @@ export type MigrateContentRunParams = Readonly<
     targetEnvironmentId: string;
     targetApiKey: string;
     skipFailedItems?: boolean;
+    tolerateMissingReferences?: boolean;
     kontentUrl?: string;
   } & (
     | ({
@@ -96,6 +97,9 @@ export const migrateContentRunInternal = async (
       apiKey: params.sourceApiKey,
       items: itemsCodenames.map((i) => ({ itemCodename: i, languageCodename: params.language })),
       baseUrl: apply(createManagementApiUrl, params.kontentUrl),
+      exportOptions: {
+        tolerateMissingReferences: params.tolerateMissingReferences ?? false,
+      },
     },
   });
 

--- a/src/modules/migrateContent/migrateContentSnapshot.ts
+++ b/src/modules/migrateContent/migrateContentSnapshot.ts
@@ -48,9 +48,7 @@ export const migrateContentSnapshotInternal = async (
     })),
     logger: getDefaultLogger(),
     baseUrl: apply(createManagementApiUrl, params.kontentUrl),
-    exportOptions: {
-      tolerateMissingReferences: params.tolerateMissingReferences ?? false,
-    },
+    tolerateMissingReferences: params.tolerateMissingReferences ?? false,
   });
 
   await storeAsync({

--- a/src/modules/migrateContent/migrateContentSnapshot.ts
+++ b/src/modules/migrateContent/migrateContentSnapshot.ts
@@ -11,6 +11,7 @@ export type MigrateContentSnapshotParams = Readonly<
     sourceEnvironmentId: string;
     sourceApiKey: string;
     filename?: string;
+    tolerateMissingReferences?: boolean;
     kontentUrl?: string;
   } & MigrateContentFilterParams &
     LogOptions
@@ -47,6 +48,9 @@ export const migrateContentSnapshotInternal = async (
     })),
     logger: getDefaultLogger(),
     baseUrl: apply(createManagementApiUrl, params.kontentUrl),
+    exportOptions: {
+      tolerateMissingReferences: params.tolerateMissingReferences ?? false,
+    },
   });
 
   await storeAsync({

--- a/tests/unit/migrateContent/migrateContentRun.test.ts
+++ b/tests/unit/migrateContent/migrateContentRun.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { migrateContentRun } from "../../../src/modules/migrateContent/migrateContentRun.ts";
+
+// Mock the migration-toolkit
+vi.mock("@kontent-ai/migration-toolkit", () => ({
+  migrateAsync: vi.fn().mockResolvedValue(undefined),
+  extractAsync: vi.fn(),
+  importAsync: vi.fn(),
+}));
+
+describe("migrateContentRun", () => {
+  it("should pass tolerateMissingReferences parameter to migrateAsync", async () => {
+    const { migrateAsync } = await import("@kontent-ai/migration-toolkit");
+    
+    await migrateContentRun({
+      sourceEnvironmentId: "source-env",
+      sourceApiKey: "source-key",
+      targetEnvironmentId: "target-env",
+      targetApiKey: "target-key",
+      language: "default",
+      items: ["item1"],
+      tolerateMissingReferences: true,
+    });
+
+    expect(migrateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceEnvironment: expect.objectContaining({
+          tolerateMissingReferences: true,
+        }),
+      }),
+    );
+  });
+
+  it("should default tolerateMissingReferences to false when not provided", async () => {
+    const { migrateAsync } = await import("@kontent-ai/migration-toolkit");
+    
+    await migrateContentRun({
+      sourceEnvironmentId: "source-env",
+      sourceApiKey: "source-key",
+      targetEnvironmentId: "target-env",
+      targetApiKey: "target-key",
+      language: "default",
+      items: ["item1"],
+    });
+
+    expect(migrateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceEnvironment: expect.objectContaining({
+          tolerateMissingReferences: false,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

Adds support for `tolerateMissingReferences` parameter to `migrate-content` commands (run and snapshot), enabling users to continue exports when referenced items or assets are missing.

This parameter is passed through to the underlying `@kontent-ai/migration-toolkit` library (requires new version to be published).

**⚠️ Dependency:** This PR depends on kontent-ai/migration-toolkit#36 being merged and published as a new version first.

Use cases:
- Content with broken references (deleted items/assets)

The parameter defaults to `false` to maintain backward compatibility.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added (integration tests pending migration-toolkit update)
- [x] Tests are passing (will pass once new migration-toolkit version is published)
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

**Prerequisites:**
- Requires new `@kontent-ai/migration-toolkit` version (see dependency note above)
- For local testing before publish, update `package.json`:
  ```json
  "@kontent-ai/migration-toolkit": "file:../migration-toolkit"
  ```

**Manual CLI Testing:**

1. Build the project: `npm run build`

2. Test `migrate-content run` with the new parameter:
```bash
node build/src/index.js migrate-content run \
  --environmentId=<your-env-id> \
  --apiKey=<your-api-key> \
  --tolerateMissingReferences
```

3. Test `migrate-content snapshot` with the new parameter:
```bash
node build/src/index.js migrate-content snapshot \
  --environmentId=<your-env-id> \
  --apiKey=<your-api-key> \
  --tolerateMissingReferences
```

4. Verify help text shows new parameter:
```bash
node build/src/index.js migrate-content run --help
node build/src/index.js migrate-content snapshot --help
```

**Programmatic API Testing:**

```typescript
import { migrateContentRun, migrateContentSnapshot } from '@kontent-ai/data-ops';

// Run with tolerateMissingReferences
await migrateContentRun({
  environmentId: 'your-env-id',
  apiKey: 'your-api-key',
  tolerateMissingReferences: true
});

// Snapshot with tolerateMissingReferences
await migrateContentSnapshot({
  environmentId: 'your-env-id',
  apiKey: 'your-api-key',
  tolerateMissingReferences: true
});
```