### PR TITLE
Correct asset size limit in README.md

### DIFF
--- a/src/commands/environment/backupRestore/README.md
+++ b/src/commands/environment/backupRestore/README.md
@@ -232,7 +232,7 @@ await restoreEnvironment(params);
 
 ### Asset Limitations
 
-- **Asset Size Limit**: The Management API accepts only assets smaller than 100 MB. If your backup file contains assets larger than that (they can be uploaded through the UI), the tool won't be able to import them.
+- **Asset Size Limit**: The Management API accepts only [assets smaller than 2 GB](https://kontent.ai/learn/docs/apis/management-api-v2/assets#upload-a-binary-file). If your backup file contains assets larger than that (they can be uploaded through the UI), the tool won't be able to import them.
 - **Asset Quality**: Assets fetched by the tool may be compressed and metadata can be missing. You may find more information about asset compression in the [quality parameter](https://kontent.ai/learn/docs/apis/image-transformation-api#a-quality-parameter) documentation.
 - **Asset Elements**: It is not possible to restore assets with elements at the moment. Assets will be imported without their elements. If you need the elements, you can adjust the asset type manually in the UI and import the elements using the Management API after the assets and taxonomies are restored.
 


### PR DESCRIPTION
Updated asset size limit in the documentation from 100 MB to 2 GB.