### PR TITLE
Confine markdown export filenames to the output directory

### DIFF
--- a/src/modules/export/markdown/writeMarkdowns.ts
+++ b/src/modules/export/markdown/writeMarkdowns.ts
@@ -49,7 +49,24 @@ const writeMarkdownFiles = async (
   params: LogOptions,
 ): Promise<void> => {
   for (const { codename, markdown } of results) {
-    await fsPromises.writeFile(path.join(outputPath, `${codename}.md`), markdown);
+    await fsPromises.writeFile(resolveItemFilePath(outputPath, codename), markdown);
     logInfo(params, "verbose", `Wrote ${codename}.md`);
   }
+};
+
+// Codenames come from the Delivery API, whose server-side rules make them traversal-safe
+// today. Guard anyway, so this never becomes an arbitrary-write primitive if that changes.
+const resolveItemFilePath = (outputPath: string, codename: string): string => {
+  const filePath = path.resolve(outputPath, `${codename}.md`);
+  const relativePath = path.relative(outputPath, filePath);
+  const isEscapingOutputDir =
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath);
+
+  if (isEscapingOutputDir) {
+    throw new Error(`Invalid item codename "${codename}" resolves outside the output directory.`);
+  }
+
+  return filePath;
 };


### PR DESCRIPTION
## What

`data-ops export markdown` built each output filename by interpolating an item's codename straight into the write path:

```ts
await fsPromises.writeFile(path.join(outputPath, `${codename}.md`), markdown);
```

`codename` is `item.system.codename`, taken verbatim from the Delivery API response. This adds a containment check so a resolved file path that lands outside the chosen output directory throws instead of being written.

## Why

Codenames are constrained server-side to `[a-z_][a-z0-9_]*`, so nothing reaching this code today can traverse. This is **defense in depth, not a live exploit** — it keeps the writer from becoming an arbitrary-write primitive if that rule ever loosens, or if the client is pointed at a non-Kontent.ai endpoint via `--kontentUrl`.

The distinction that matters is *who chooses the target*, not whose permissions perform the write. Every write happens with the operator's permissions either way; a remote HTTP response choosing the destination is a confused-deputy gap, a human typing `--output` is not.

## Scope

Aikido flagged 9 locations. **Only this one is fixed.** The other 8 (`generateSyncModel.ts`, `sync/utils/fileUtils.ts`, `sync/utils/getContentModel.ts`, `sync/validation.ts`) join an operator-supplied CLI path (`--folderName`, `--outPath`) with a **hardcoded filename constant** from `sync/constants/filename.ts` or the `as const` `entityToFilenames` map. No remote data reaches those paths.

Confining operator-supplied paths would reject `--output ../my-project` and absolute paths — both documented behavior — while providing no security benefit, since the operator can already write anywhere their OS permissions allow.

## Behavior

Driven through the compiled `writeMarkdowns`:

| codename | before | after |
|---|---|---|
| `hero_banner` | written | written |
| `../CANARY` | **escapes output dir** | throws |
| `../../../../tmp/evil` | **escapes output dir** | throws |
| `/etc/passwd` | silently written to `<out>/etc/passwd.md` | throws |
| `..hidden_draft` | written | written |

`path.resolve` (not `path.join`) makes the `isAbsolute` branch load-bearing, turning the `/etc/passwd` case from a silent mangle into an explicit error. The `..` check is anchored on `path.sep` so a legitimate filename beginning with two dots is not falsely rejected.

## Known limit

Containment is **lexical**, not physical — `path.resolve` does not follow symlinks. A pre-existing symlink inside the output directory can still redirect a write. Exploiting that requires a local write foothold in the output directory plus predictable codenames; out of scope here, and mitigated operationally by not exporting into world-writable directories.

## Checks

- `tsc --noEmit` — clean
- `biome check` — clean
- `pnpm test:unit` — 38 files, 237 tests, all pass
- `pnpm build` — clean

No behavior change for any valid codename, so no existing test or snapshot is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)