### PR TITLE
Set persist-credentials: false on actions/checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js from .nvmrc file

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js from .nvmrc file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js from .nvmrc file


### PR DESCRIPTION
## Summary

`actions/checkout` defaults `persist-credentials` to `true` ([confirmed in the v6 `action.yml`](https://github.com/actions/checkout/blob/v6/action.yml)), writing the job's `GITHUB_TOKEN` into the checked-out repo's `.git/config` as an `http.<url>.extraheader`. The token then sits on disk for the remainder of the job, readable by every subsequent step — including any third-party code those steps execute (`biome`, `eslint`, `tsc`, `vitest`, and the built CLI under `test:integration`).

No workflow in this repo performs an authenticated git operation, so nothing needs the persisted credential:

- No `git push`, commit, or tag creation anywhere.
- `release.yml` publishes to npm via OIDC (`id-token: write`) and passes `--no-git-checks` to `pnpm publish`.
- No `prepare` / `prepublish` / `postinstall` lifecycle script, no husky, no changesets, no semantic-release.

This is consistent with the supply-chain posture already in the repo (`minimumReleaseAge: 4320` in `pnpm-workspace.yaml`) — it keeps the token out of the blast radius of compromised third-party code.

## Notes

- `build.yml`, `unitTests.yml`, `integrationTests.yml` declare no `permissions:` block, so they inherit the repo/org default, which can be a **write-capable** `contents` token on `push: [main]` and same-repo PRs. This is where the real exposure is.
- `release.yml` declares `permissions: { id-token: write }`, and declaring any `permissions` key drops all unlisted scopes to `none` — so its token has no `contents` access and the change is a no-op there. Included anyway for consistency, so the safe default doesn't silently regress if that block is ever widened.

Adding explicit `permissions: contents: read` blocks to the three unscoped workflows would be complementary hardening, but it's a different change: it narrows what the token can do rather than stopping it from being written to disk. Left out of this PR.

## Test plan

- [x] All four workflows re-parsed; each checkout step resolves to `{uses: actions/checkout@v6, with: {persist-credentials: false}}`.
- [x] No TypeScript source touched — `build`, `checkTests`, and both test suites are unaffected. Neither Biome (scoped to `src/**`, no YAML support) nor ESLint (`eslint src --ext ts,tsx`) reads `.github/workflows/*.yml`.
- [ ] CI green on this PR confirms checkout still succeeds without the credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)