### PR TITLE
redact credentials in error output at serialization sinks

### DIFF
--- a/src/commands/sync/diff/diff.ts
+++ b/src/commands/sync/diff/diff.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../modules/sync/diffEnvironments.js";
 import { createAdvancedDiffFile, printDiff } from "../../../modules/sync/printDiff.js";
 import type { RegisterCommand } from "../../../types/yargs.js";
-import { simplifyErrors } from "../../../utils/error.js";
+import { redactingReplacer, simplifyErrors } from "../../../utils/error.js";
 
 const commandName = "diff";
 
@@ -110,7 +110,7 @@ const syncDiffCli = async (params: syncDiffCliParams) => {
       ? createAdvancedDiffFile({ diffModel, params: { ...resolvedParams, entities } })
       : printDiff(diffModel, new Set(entities), params);
   } catch (e) {
-    logError(params, e instanceof Error ? e.message : JSON.stringify(e));
+    logError(params, e instanceof Error ? e.message : JSON.stringify(e, redactingReplacer));
     process.exit(1);
   }
 };

--- a/src/modules/migrations/utils/errUtils.ts
+++ b/src/modules/migrations/utils/errUtils.ts
@@ -1,4 +1,5 @@
 import { type LogOptions, logError } from "../../../log.js";
+import { redactingReplacer } from "../../../utils/error.js";
 
 type Err = { err: unknown };
 
@@ -8,7 +9,7 @@ export const handleErr = <T>(entity: WithErr<T>, logOptions: LogOptions, message
   if ("err" in entity) {
     logError(
       logOptions,
-      `${message ?? ""}${entity.err instanceof Error ? entity.err.message : JSON.stringify(entity.err)}`,
+      `${message ?? ""}${entity.err instanceof Error ? entity.err.message : JSON.stringify(entity.err, redactingReplacer)}`,
     );
 
     throw new Error(

--- a/src/modules/migrations/utils/migrationUtils.ts
+++ b/src/modules/migrations/utils/migrationUtils.ts
@@ -7,6 +7,7 @@ import chalk from "chalk";
 import { match, P } from "ts-pattern";
 
 import { type LogOptions, logError, logInfo } from "../../../log.js";
+import { redactingReplacer } from "../../../utils/error.js";
 import { DateLevel, serializeDateForFileName } from "../../../utils/files.js";
 import { seriallyReduce } from "../../../utils/requests.js";
 import {
@@ -167,7 +168,7 @@ export const executeMigrations = async (
       } catch (e) {
         logError(
           logOptions,
-          `Error occured in ${migration.name}: ${e instanceof Error ? e.message : JSON.stringify(e)}`,
+          `Error occured in ${migration.name}: ${e instanceof Error ? e.message : JSON.stringify(e, redactingReplacer)}`,
         );
 
         return {

--- a/src/modules/sync/sync/assetFolders.ts
+++ b/src/modules/sync/sync/assetFolders.ts
@@ -2,7 +2,7 @@ import type { AssetFolderModels, ManagementClient } from "@kontent-ai/management
 import { match } from "ts-pattern";
 
 import { type LogOptions, logError, logInfo } from "../../../log.js";
-import { handleKontentErrors, throwError } from "../../../utils/error.js";
+import { handleKontentErrors, redactingReplacer, throwError } from "../../../utils/error.js";
 import { apply, not } from "../../../utils/function.js";
 import { omit } from "../../../utils/object.js";
 import { serially } from "../../../utils/requests.js";
@@ -37,7 +37,7 @@ export const syncAssetFolders = async (
                 logError(
                   logOptions,
                   "error",
-                  `Failed to remove asset folder "${operation.path}" error: ${JSON.stringify(err)}. Skipping it.`,
+                  `Failed to remove asset folder "${operation.path}" error: ${JSON.stringify(err, redactingReplacer)}. Skipping it.`,
                 );
 
                 return undefined;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -36,7 +36,28 @@ export const simplifyAxiosErrors = (error: unknown): unknown =>
         method: error.config?.method,
         responseBody: error.response?.config.data,
         requestBody: error.config?.data,
-        requestHeaders: error.config?.headers.normalize(true).toJSON(),
+        requestHeaders: redactSecrets(error.config?.headers.normalize(true).toJSON()),
         code: error.code,
       }
     : error;
+
+/**
+ * A `JSON.stringify` replacer that masks credential values at any depth. Pass it to every sink that
+ * serializes a raw error, whose nested request headers would otherwise expose the bearer token.
+ */
+export const redactingReplacer = (key: string, value: unknown): unknown =>
+  secretKeyPattern.test(key) ? redactedValue : value;
+
+const redactedValue = "***redacted***";
+
+const secretKeyPattern = /authorization|api[-_]?key/i;
+
+const redactSecrets = (headers: unknown): unknown =>
+  headers && typeof headers === "object"
+    ? Object.fromEntries(
+        Object.entries(headers).map(([key, value]) => [
+          key,
+          secretKeyPattern.test(key) ? redactedValue : value,
+        ]),
+      )
+    : headers;

--- a/tests/unit/utils/error.test.ts
+++ b/tests/unit/utils/error.test.ts
@@ -1,0 +1,96 @@
+import { SharedModels } from "@kontent-ai/management-sdk";
+import { AxiosError, AxiosHeaders } from "axios";
+import { describe, expect, it } from "vitest";
+
+import { redactingReplacer, simplifyAxiosErrors } from "../../../src/utils/error.ts";
+
+const fakeToken = "fake-token-123";
+const bearerToken = `Bearer ${fakeToken}`;
+
+const createAxiosError = () => {
+  const headers = new AxiosHeaders({
+    Authorization: bearerToken,
+    "Content-Type": "application/json",
+  });
+
+  const config = {
+    url: "https://manage.kontent.ai/v2/projects/env-id/items",
+    method: "post",
+    headers,
+    data: '{"name":"item"}',
+  };
+
+  return new AxiosError(
+    "Request failed with status code 401",
+    "ERR_BAD_REQUEST",
+    config as never,
+    {},
+    { status: 401, statusText: "Unauthorized", headers: {}, config } as never,
+  );
+};
+
+describe("simplifyAxiosErrors", () => {
+  it("masks the credential in the request headers while keeping the key and the rest", () => {
+    const simplified = simplifyAxiosErrors(createAxiosError()) as {
+      requestHeaders: Record<string, unknown>;
+      status: number;
+    };
+
+    expect(simplified.requestHeaders["Authorization"]).toBe("***redacted***");
+    expect(simplified.requestHeaders["Content-Type"]).toBe("application/json");
+    expect(simplified.status).toBe(401);
+    expect(JSON.stringify(simplified)).not.toContain(fakeToken);
+  });
+
+  it("returns a non-axios error untouched", () => {
+    const plain = new Error("boom");
+
+    expect(simplifyAxiosErrors(plain)).toBe(plain);
+  });
+});
+
+describe("redactingReplacer", () => {
+  it("masks a raw axios error nested in a Kontent error without dropping other fields", () => {
+    const kontentError = new SharedModels.ContentManagementBaseKontentError({
+      message: "The provided API key is invalid.",
+      requestId: "request-id-42",
+      errorCode: 5,
+      originalError: createAxiosError(),
+      validationErrors: [],
+    });
+
+    const output = JSON.stringify(kontentError, redactingReplacer);
+
+    expect(output).not.toContain(fakeToken);
+    expect(output).toContain("The provided API key is invalid.");
+    expect(output).toContain("request-id-42");
+  });
+
+  it("masks credential keys at any depth and leaves harmless keys alone", () => {
+    const payload = {
+      level1: {
+        authorization: bearerToken,
+        level2: {
+          "api-key": fakeToken,
+          api_key: fakeToken,
+          apiKey: fakeToken,
+          harmless: "keep-me",
+        },
+      },
+    };
+
+    const output = JSON.stringify(payload, redactingReplacer);
+
+    expect(output).not.toContain(fakeToken);
+    expect(output).toContain("keep-me");
+    expect(output.match(/\*\*\*redacted\*\*\*/g)).toHaveLength(4);
+  });
+
+  it("leaves the shape unchanged apart from the masked values", () => {
+    const parsed = JSON.parse(
+      JSON.stringify({ status: 401, headers: { authorization: bearerToken } }, redactingReplacer),
+    );
+
+    expect(parsed).toEqual({ status: 401, headers: { authorization: "***redacted***" } });
+  });
+});


### PR DESCRIPTION
### Motivation

Error output could include sensitive request-header values. When a request fails, several sinks serialized the raw axios/Kontent error to stderr via `JSON.stringify`, which pulls in the full request headers.

**What:** Mask sensitive header values (`authorization`, `api-key`) wherever an error is serialized, while leaving every error's shape and type exactly as before.

**Why this approach:** Deliberately kept minimal and **non-breaking**. We considered introducing a dedicated error type and converting errors at the module boundary, but every module function has a public counterpart, so changing what they throw would be a breaking change — that's left for the next major. This PR only masks values, so it ships as a patch. The stderr output shape is also unchanged (a function replacer masks values in place rather than reshaping the object), so behavior is identical apart from the masked values.

**How:**
- Added `redactingReplacer` in `utils/error.ts` — masks sensitive keys at any depth — and applied it to the four bare `JSON.stringify(e)` sinks (`diff.ts`, `migrationUtils.ts`, `assetFolders.ts`, `errUtils.ts`).
- `simplifyAxiosErrors` now masks the sensitive request-header values in place (keeps the keys).
- Left the `JSON.stringify(e, Object.getOwnPropertyNames(e))` allowlist sinks untouched — they already omit nested header values, and changing them would alter output shape.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) — n/a
- [x] Temporary settings have been reverted to defaults

### How to test

Run any command against an environment with an invalid API key (e.g. `environment backup` or `migrations run`) and confirm the error output shows `"authorization": "***redacted***"`. Covered by `tests/unit/utils/error.test.ts`.
